### PR TITLE
ci: update notification to use a different GH action

### DIFF
--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -1,14 +1,12 @@
 name: Notifications
 
 on:
-  issue_comment:
-    types: [created, edited, deleted]
-  push:
-    branches: [main]
   pull_request:
-    types: [opened, edited, closed, reopened, synchronize]
-  deployment_status:
-  release:
+  push:
+    branches:
+     - main
+     - beta
+     - qa
 
 jobs:
   notify:
@@ -16,9 +14,9 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-
+    
     steps:
-    - id: 'notify_google_chat'
-      uses: 'google-github-actions/send-google-chat-webhook@v0.0.4'
-      with:
-        webhook_url: '${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}'
+      - name: Notify Google Chat
+        uses: SimonScholz/google-chat-action@main
+        with:
+          webhook_url: '${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}'


### PR DESCRIPTION
Switch the a new GH action that better supports PR and push notifications.

https://github.com/SimonScholz/google-chat-action