### PR TITLE
chore: add evaluation details and OpenTelemetry to hooks

### DIFF
--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -1,5 +1,6 @@
-// Hook interface and default hooks.
+// Hook interface with OpenTelemetry support
 import 'dart:async';
+import 'dart:convert';
 
 /// Defines the stages in the hook lifecycle
 /// Used internally by the hook manager for execution ordering
@@ -7,7 +8,7 @@ enum HookStage {
   BEFORE, // Before flag evaluation
   AFTER, // After successful evaluation
   ERROR, // When an error occurs
-  FINALLY // Always executed last
+  FINALLY, // Always executed last
 }
 
 /// Hook priority levels
@@ -15,7 +16,7 @@ enum HookPriority {
   CRITICAL, // Highest priority, executes first
   HIGH, // High priority
   NORMAL, // Default priority
-  LOW // Lowest priority
+  LOW, // Lowest priority
 }
 
 /// Configuration for hook behavior
@@ -46,6 +47,25 @@ class HookMetadata {
   });
 }
 
+/// Details about the evaluation result
+class EvaluationDetails {
+  final String flagKey;
+  final dynamic value;
+  final String? variant;
+  final String reason;
+  final DateTime evaluationTime;
+  final Map<String, dynamic>? additionalDetails;
+
+  EvaluationDetails({
+    required this.flagKey,
+    required this.value,
+    this.variant,
+    this.reason = 'DEFAULT',
+    required this.evaluationTime,
+    this.additionalDetails,
+  });
+}
+
 /// Context passed to hooks during execution
 class HookContext {
   final String flagKey;
@@ -63,6 +83,13 @@ class HookContext {
   });
 }
 
+/// Optional hints for hook execution
+class HookHints {
+  final Map<String, dynamic> hints;
+
+  const HookHints({this.hints = const {}});
+}
+
 /// Interface for implementing hooks
 abstract class Hook {
   /// Hook metadata and configuration
@@ -77,8 +104,12 @@ abstract class Hook {
   /// When an error occurs
   Future<void> error(HookContext context);
 
-  /// Always executed at the end
-  Future<void> finally_(HookContext context);
+  /// Always executed at the end, now with evaluation details parameter
+  Future<void> finally_(
+    HookContext context,
+    EvaluationDetails? evaluationDetails, [
+    HookHints? hints,
+  ]);
 }
 
 /// Manager for hook registration and execution
@@ -90,8 +121,8 @@ class HookManager {
   HookManager({
     bool failFast = false,
     Duration defaultTimeout = const Duration(seconds: 5),
-  })  : _failFast = failFast,
-        _defaultTimeout = defaultTimeout;
+  }) : _failFast = failFast,
+       _defaultTimeout = defaultTimeout;
 
   /// Register a new hook
   void addHook(Hook hook) {
@@ -106,6 +137,8 @@ class HookManager {
     Map<String, dynamic>? context, {
     dynamic result,
     Exception? error,
+    EvaluationDetails? evaluationDetails,
+    HookHints? hints,
   }) async {
     final hookContext = HookContext(
       flagKey: flagKey,
@@ -121,6 +154,8 @@ class HookManager {
           stage,
           hookContext,
           hook.metadata.config.timeout,
+          evaluationDetails,
+          hints,
         );
       } catch (e) {
         if (_failFast || !hook.metadata.config.continueOnError) {
@@ -133,8 +168,9 @@ class HookManager {
 
   /// Sort hooks by priority
   void _sortHooks() {
-    _hooks.sort((a, b) =>
-        a.metadata.priority.index.compareTo(b.metadata.priority.index));
+    _hooks.sort(
+      (a, b) => a.metadata.priority.index.compareTo(b.metadata.priority.index),
+    );
   }
 
   /// Execute a single hook with timeout
@@ -143,6 +179,8 @@ class HookManager {
     HookStage stage,
     HookContext context,
     Duration? timeout,
+    EvaluationDetails? evaluationDetails,
+    HookHints? hints,
   ) async {
     final effectiveTimeout = timeout ?? _defaultTimeout;
 
@@ -158,7 +196,7 @@ class HookManager {
         hookExecution = hook.error(context);
         break;
       case HookStage.FINALLY:
-        hookExecution = hook.finally_(context);
+        hookExecution = hook.finally_(context, evaluationDetails, hints);
         break;
     }
 
@@ -170,5 +208,271 @@ class HookManager {
         );
       },
     );
+  }
+}
+
+/// A base hook implementation with empty methods
+abstract class BaseHook implements Hook {
+  @override
+  final HookMetadata metadata;
+
+  BaseHook({required this.metadata});
+
+  @override
+  Future<void> before(HookContext context) async {}
+
+  @override
+  Future<void> after(HookContext context) async {}
+
+  @override
+  Future<void> error(HookContext context) async {}
+
+  @override
+  Future<void> finally_(
+    HookContext context,
+    EvaluationDetails? evaluationDetails, [
+    HookHints? hints,
+  ]) async {}
+}
+
+//
+// OpenTelemetry Support
+//
+
+/// OpenTelemetry semantic conventions for feature flags
+/// Based on https://opentelemetry.io/docs/specs/semconv/feature-flags/feature-flags-spans/
+class OTelFeatureFlagConstants {
+  /// Common attributes
+  static const String FEATURE_FLAG = 'feature_flag';
+  static const String FLAG_KEY = 'feature_flag.key';
+  static const String FLAG_PROVIDER_NAME = 'feature_flag.provider_name';
+  static const String FLAG_VARIANT = 'feature_flag.variant';
+
+  /// Value type specific attributes
+  static const String FLAG_EVALUATED = 'feature_flag.evaluated';
+  static const String FLAG_VALUE_TYPE = 'feature_flag.value_type';
+  static const String FLAG_VALUE_BOOLEAN = 'feature_flag.value.boolean';
+  static const String FLAG_VALUE_STRING = 'feature_flag.value.string';
+  static const String FLAG_VALUE_INT = 'feature_flag.value.int';
+  static const String FLAG_VALUE_FLOAT = 'feature_flag.value.float';
+
+  /// Reason constants
+  static const String REASON = 'feature_flag.reason';
+  static const String REASON_DEFAULT = 'DEFAULT';
+  static const String REASON_TARGETING_MATCH = 'TARGETING_MATCH';
+  static const String REASON_SPLIT = 'SPLIT';
+  static const String REASON_CACHED = 'CACHED';
+  static const String REASON_ERROR = 'ERROR';
+  static const String REASON_DISABLED = 'DISABLED';
+  static const String REASON_UNKNOWN = 'UNKNOWN';
+
+  /// Value types
+  static const String TYPE_BOOLEAN = 'BOOLEAN';
+  static const String TYPE_STRING = 'STRING';
+  static const String TYPE_INT = 'INTEGER';
+  static const String TYPE_DOUBLE = 'FLOAT';
+  static const String TYPE_OBJECT = 'OBJECT';
+}
+
+/// Represents an OpenTelemetry attribute
+class OTelAttribute {
+  final String key;
+  final dynamic value;
+
+  const OTelAttribute(this.key, this.value);
+
+  Map<String, dynamic> toJson() => {key: value};
+}
+
+/// A collection of OpenTelemetry attributes
+class OTelAttributes {
+  final List<OTelAttribute> attributes;
+
+  const OTelAttributes(this.attributes);
+
+  Map<String, dynamic> toJson() {
+    final result = <String, dynamic>{};
+    for (final attr in attributes) {
+      result.addAll(attr.toJson());
+    }
+    return result;
+  }
+
+  @override
+  String toString() => jsonEncode(toJson());
+}
+
+/// Utility class for generating OpenTelemetry-compatible telemetry from feature flag evaluations
+class OpenTelemetryUtil {
+  /// Creates OpenTelemetry-compatible attributes for a feature flag evaluation
+  ///
+  /// These attributes follow the OpenTelemetry semantic conventions for feature flags.
+  /// They can be used with any OpenTelemetry-compatible telemetry system.
+  static OTelAttributes createOTelAttributes({
+    required String flagKey,
+    required dynamic value,
+    String? providerName,
+    String? variant,
+    String reason = OTelFeatureFlagConstants.REASON_DEFAULT,
+    Map<String, dynamic>? evaluationContext,
+  }) {
+    final attributes = <OTelAttribute>[];
+
+    // Add common attributes
+    attributes.add(OTelAttribute(OTelFeatureFlagConstants.FLAG_KEY, flagKey));
+    attributes.add(
+      OTelAttribute(OTelFeatureFlagConstants.FLAG_EVALUATED, true),
+    );
+
+    if (providerName != null && providerName.isNotEmpty) {
+      attributes.add(
+        OTelAttribute(
+          OTelFeatureFlagConstants.FLAG_PROVIDER_NAME,
+          providerName,
+        ),
+      );
+    }
+
+    if (variant != null && variant.isNotEmpty) {
+      attributes.add(
+        OTelAttribute(OTelFeatureFlagConstants.FLAG_VARIANT, variant),
+      );
+    }
+
+    attributes.add(OTelAttribute(OTelFeatureFlagConstants.REASON, reason));
+
+    // Add value and determine type
+    if (value != null) {
+      if (value is bool) {
+        attributes.add(
+          OTelAttribute(
+            OTelFeatureFlagConstants.FLAG_VALUE_TYPE,
+            OTelFeatureFlagConstants.TYPE_BOOLEAN,
+          ),
+        );
+        attributes.add(
+          OTelAttribute(OTelFeatureFlagConstants.FLAG_VALUE_BOOLEAN, value),
+        );
+      } else if (value is String) {
+        attributes.add(
+          OTelAttribute(
+            OTelFeatureFlagConstants.FLAG_VALUE_TYPE,
+            OTelFeatureFlagConstants.TYPE_STRING,
+          ),
+        );
+        attributes.add(
+          OTelAttribute(OTelFeatureFlagConstants.FLAG_VALUE_STRING, value),
+        );
+      } else if (value is int) {
+        attributes.add(
+          OTelAttribute(
+            OTelFeatureFlagConstants.FLAG_VALUE_TYPE,
+            OTelFeatureFlagConstants.TYPE_INT,
+          ),
+        );
+        attributes.add(
+          OTelAttribute(OTelFeatureFlagConstants.FLAG_VALUE_INT, value),
+        );
+      } else if (value is double) {
+        attributes.add(
+          OTelAttribute(
+            OTelFeatureFlagConstants.FLAG_VALUE_TYPE,
+            OTelFeatureFlagConstants.TYPE_DOUBLE,
+          ),
+        );
+        attributes.add(
+          OTelAttribute(OTelFeatureFlagConstants.FLAG_VALUE_FLOAT, value),
+        );
+      } else {
+        attributes.add(
+          OTelAttribute(
+            OTelFeatureFlagConstants.FLAG_VALUE_TYPE,
+            OTelFeatureFlagConstants.TYPE_OBJECT,
+          ),
+        );
+        // For non-primitive types, we convert to a string representation
+        attributes.add(
+          OTelAttribute(
+            OTelFeatureFlagConstants.FLAG_VALUE_STRING,
+            value.toString(),
+          ),
+        );
+      }
+    }
+
+    return OTelAttributes(attributes);
+  }
+
+  /// Creates OpenTelemetry-compatible attributes from EvaluationDetails
+  ///
+  /// This is a convenience method for use in hooks, especially the finally_ hook.
+  static OTelAttributes fromEvaluationDetails(
+    EvaluationDetails details, {
+    String? providerName,
+  }) {
+    return createOTelAttributes(
+      flagKey: details.flagKey,
+      value: details.value,
+      providerName: providerName,
+      variant: details.variant,
+      reason: details.reason,
+    );
+  }
+
+  /// Creates OpenTelemetry-compatible attributes from HookContext
+  ///
+  /// This is a convenience method for use in hooks when EvaluationDetails is not available.
+  static OTelAttributes fromHookContext(
+    HookContext context, {
+    String? providerName,
+    String? reason,
+  }) {
+    return createOTelAttributes(
+      flagKey: context.flagKey,
+      value: context.result,
+      providerName: providerName,
+      reason:
+          reason ??
+          (context.error != null
+              ? OTelFeatureFlagConstants.REASON_ERROR
+              : OTelFeatureFlagConstants.REASON_DEFAULT),
+      evaluationContext: context.evaluationContext,
+    );
+  }
+}
+
+/// A hook that generates OpenTelemetry-compatible telemetry
+class OpenTelemetryHook extends BaseHook {
+  final String providerName;
+  final void Function(OTelAttributes)? telemetryCallback;
+
+  OpenTelemetryHook({
+    required this.providerName,
+    this.telemetryCallback,
+    HookPriority priority = HookPriority.NORMAL,
+  }) : super(
+         metadata: HookMetadata(name: 'OpenTelemetryHook', priority: priority),
+       );
+
+  @override
+  Future<void> finally_(
+    HookContext context,
+    EvaluationDetails? evaluationDetails, [
+    HookHints? hints,
+  ]) async {
+    // Generate OpenTelemetry attributes
+    final otelAttributes =
+        evaluationDetails != null
+            ? OpenTelemetryUtil.fromEvaluationDetails(
+              evaluationDetails,
+              providerName: providerName,
+            )
+            : OpenTelemetryUtil.fromHookContext(
+              context,
+              providerName: providerName,
+            );
+
+    // Call the telemetry callback if provided
+    telemetryCallback?.call(otelAttributes);
   }
 }

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-Testing for pipeline trigger.  Add content to test 

--- a/test/hooks_test.dart
+++ b/test/hooks_test.dart
@@ -5,14 +5,13 @@ import '../lib/hooks.dart';
 class TestHook implements Hook {
   final List<String> executionOrder = [];
   final HookPriority _priority;
+  bool receivedEvaluationDetails = false;
 
   TestHook([this._priority = HookPriority.NORMAL]);
 
   @override
-  HookMetadata get metadata => HookMetadata(
-        name: 'TestHook',
-        priority: _priority,
-      );
+  HookMetadata get metadata =>
+      HookMetadata(name: 'TestHook', priority: _priority);
 
   @override
   Future<void> before(HookContext context) async {
@@ -30,46 +29,49 @@ class TestHook implements Hook {
   }
 
   @override
-  Future<void> finally_(HookContext context) async {
+  Future<void> finally_(
+    HookContext context,
+    EvaluationDetails? evaluationDetails, [
+    HookHints? hints,
+  ]) async {
     executionOrder.add('finally');
+    if (evaluationDetails != null) {
+      receivedEvaluationDetails = true;
+    }
+    if (hints != null) {
+      executionOrder.add('with_hints');
+    }
   }
 }
 
-class ErrorHook implements Hook {
-  @override
-  HookMetadata get metadata => HookMetadata(name: 'ErrorHook');
+class OTelTestHook extends OpenTelemetryHook {
+  final List<Map<String, dynamic>> capturedAttributes = [];
 
-  @override
-  Future<void> before(HookContext context) async {
-    throw Exception('Test error');
-  }
-
-  @override
-  Future<void> after(HookContext context) async {}
-  @override
-  Future<void> error(HookContext context) async {}
-  @override
-  Future<void> finally_(HookContext context) async {}
-}
-
-class SlowHook implements Hook {
-  @override
-  HookMetadata get metadata => HookMetadata(
-        name: 'SlowHook',
-        config: HookConfig(timeout: Duration(milliseconds: 100)),
+  OTelTestHook({required String providerName})
+    : super(
+        providerName: providerName,
+        telemetryCallback: null, // We'll override the finally_ method
       );
 
   @override
-  Future<void> before(HookContext context) async {
-    await Future.delayed(Duration(milliseconds: 200));
-  }
+  Future<void> finally_(
+    HookContext context,
+    EvaluationDetails? evaluationDetails, [
+    HookHints? hints,
+  ]) async {
+    final otelAttributes =
+        evaluationDetails != null
+            ? OpenTelemetryUtil.fromEvaluationDetails(
+              evaluationDetails,
+              providerName: providerName,
+            )
+            : OpenTelemetryUtil.fromHookContext(
+              context,
+              providerName: providerName,
+            );
 
-  @override
-  Future<void> after(HookContext context) async {}
-  @override
-  Future<void> error(HookContext context) async {}
-  @override
-  Future<void> finally_(HookContext context) async {}
+    capturedAttributes.add(otelAttributes.toJson());
+  }
 }
 
 void main() {
@@ -84,67 +86,204 @@ void main() {
     });
 
     test('executes hooks in correct order', () async {
-      await manager.executeHooks(
-        HookStage.BEFORE,
-        'test-flag',
-        {'user': 'test'},
-      );
+      await manager.executeHooks(HookStage.BEFORE, 'test-flag', {
+        'user': 'test',
+      });
 
-      await manager.executeHooks(
-        HookStage.AFTER,
-        'test-flag',
-        {'user': 'test'},
-        result: true,
-      );
+      await manager.executeHooks(HookStage.AFTER, 'test-flag', {
+        'user': 'test',
+      }, result: true);
 
-      await manager.executeHooks(
-        HookStage.FINALLY,
-        'test-flag',
-        {'user': 'test'},
-      );
+      await manager.executeHooks(HookStage.FINALLY, 'test-flag', {
+        'user': 'test',
+      });
 
       expect(testHook.executionOrder, ['before', 'after', 'finally']);
     });
 
-    test('handles hook timeouts', () async {
-      final slowHook = SlowHook();
-      manager = HookManager(failFast: true);
-      manager.addHook(slowHook);
+    test('passes evaluation details to finally hook', () async {
+      final evaluationDetails = EvaluationDetails(
+        flagKey: 'test-flag',
+        value: true,
+        evaluationTime: DateTime.now(),
+        reason: 'TARGETING_MATCH',
+        variant: 'control',
+      );
 
-      await expectLater(
-        manager.executeHooks(HookStage.BEFORE, 'test-flag', {}),
-        throwsA(isA<TimeoutException>()),
+      await manager.executeHooks(HookStage.FINALLY, 'test-flag', {
+        'user': 'test',
+      }, evaluationDetails: evaluationDetails);
+
+      expect(testHook.receivedEvaluationDetails, isTrue);
+    });
+
+    test('passes hook hints to finally hook', () async {
+      final hints = HookHints(hints: {'source': 'test'});
+
+      await manager.executeHooks(HookStage.FINALLY, 'test-flag', {
+        'user': 'test',
+      }, hints: hints);
+
+      expect(testHook.executionOrder, contains('with_hints'));
+    });
+  });
+
+  group('OpenTelemetryUtil', () {
+    test('creates attributes for boolean flag', () {
+      final attributes = OpenTelemetryUtil.createOTelAttributes(
+        flagKey: 'test-flag',
+        value: true,
+        providerName: 'test-provider',
+      );
+
+      final jsonMap = attributes.toJson();
+
+      expect(jsonMap[OTelFeatureFlagConstants.FLAG_KEY], equals('test-flag'));
+      expect(
+        jsonMap[OTelFeatureFlagConstants.FLAG_PROVIDER_NAME],
+        equals('test-provider'),
+      );
+      expect(jsonMap[OTelFeatureFlagConstants.FLAG_EVALUATED], isTrue);
+      expect(
+        jsonMap[OTelFeatureFlagConstants.FLAG_VALUE_TYPE],
+        equals(OTelFeatureFlagConstants.TYPE_BOOLEAN),
+      );
+      expect(jsonMap[OTelFeatureFlagConstants.FLAG_VALUE_BOOLEAN], isTrue);
+      expect(
+        jsonMap[OTelFeatureFlagConstants.REASON],
+        equals(OTelFeatureFlagConstants.REASON_DEFAULT),
       );
     });
 
-    test('sorts hooks by priority', () async {
-      final highPriorityHook = TestHook(HookPriority.HIGH);
-      final lowPriorityHook = TestHook(HookPriority.LOW);
+    test('creates attributes for string flag', () {
+      final attributes = OpenTelemetryUtil.createOTelAttributes(
+        flagKey: 'test-flag',
+        value: 'test-value',
+        providerName: 'test-provider',
+        variant: 'control',
+        reason: OTelFeatureFlagConstants.REASON_TARGETING_MATCH,
+      );
 
-      manager
-        ..addHook(lowPriorityHook)
-        ..addHook(highPriorityHook);
+      final jsonMap = attributes.toJson();
 
-      await manager.executeHooks(HookStage.BEFORE, 'test-flag', {});
-
+      expect(jsonMap[OTelFeatureFlagConstants.FLAG_VARIANT], equals('control'));
       expect(
-        highPriorityHook.executionOrder,
-        contains('before'),
+        jsonMap[OTelFeatureFlagConstants.FLAG_VALUE_TYPE],
+        equals(OTelFeatureFlagConstants.TYPE_STRING),
       );
       expect(
-        lowPriorityHook.executionOrder,
-        contains('before'),
+        jsonMap[OTelFeatureFlagConstants.FLAG_VALUE_STRING],
+        equals('test-value'),
+      );
+      expect(
+        jsonMap[OTelFeatureFlagConstants.REASON],
+        equals(OTelFeatureFlagConstants.REASON_TARGETING_MATCH),
       );
     });
 
-    test('respects failFast setting', () async {
-      manager = HookManager(failFast: true);
-      final errorHook = ErrorHook();
-      manager.addHook(errorHook);
+    test('creates attributes for numeric flags', () {
+      final intAttributes = OpenTelemetryUtil.createOTelAttributes(
+        flagKey: 'int-flag',
+        value: 42,
+        providerName: 'test-provider',
+      );
+
+      final doubleAttributes = OpenTelemetryUtil.createOTelAttributes(
+        flagKey: 'double-flag',
+        value: 3.14,
+        providerName: 'test-provider',
+      );
 
       expect(
-        () => manager.executeHooks(HookStage.BEFORE, 'test-flag', {}),
-        throwsException,
+        intAttributes.toJson()[OTelFeatureFlagConstants.FLAG_VALUE_TYPE],
+        equals(OTelFeatureFlagConstants.TYPE_INT),
+      );
+      expect(
+        intAttributes.toJson()[OTelFeatureFlagConstants.FLAG_VALUE_INT],
+        equals(42),
+      );
+
+      expect(
+        doubleAttributes.toJson()[OTelFeatureFlagConstants.FLAG_VALUE_TYPE],
+        equals(OTelFeatureFlagConstants.TYPE_DOUBLE),
+      );
+      expect(
+        doubleAttributes.toJson()[OTelFeatureFlagConstants.FLAG_VALUE_FLOAT],
+        equals(3.14),
+      );
+    });
+  });
+
+  group('OpenTelemetryHook', () {
+    test('generates telemetry from evaluation details', () async {
+      final otelHook = OTelTestHook(providerName: 'test-provider');
+
+      final evaluationDetails = EvaluationDetails(
+        flagKey: 'test-flag',
+        value: true,
+        evaluationTime: DateTime.now(),
+        variant: 'control',
+      );
+
+      await otelHook.finally_(
+        HookContext(flagKey: 'test-flag', result: true),
+        evaluationDetails,
+      );
+
+      expect(otelHook.capturedAttributes.length, equals(1));
+      expect(
+        otelHook.capturedAttributes[0][OTelFeatureFlagConstants.FLAG_KEY],
+        equals('test-flag'),
+      );
+      expect(
+        otelHook.capturedAttributes[0][OTelFeatureFlagConstants
+            .FLAG_VALUE_BOOLEAN],
+        isTrue,
+      );
+      expect(
+        otelHook.capturedAttributes[0][OTelFeatureFlagConstants.FLAG_VARIANT],
+        equals('control'),
+      );
+    });
+
+    test(
+      'generates telemetry from context when details not available',
+      () async {
+        final otelHook = OTelTestHook(providerName: 'test-provider');
+
+        await otelHook.finally_(
+          HookContext(flagKey: 'test-flag', result: 'test-value'),
+          null,
+        );
+
+        expect(otelHook.capturedAttributes.length, equals(1));
+        expect(
+          otelHook.capturedAttributes[0][OTelFeatureFlagConstants.FLAG_KEY],
+          equals('test-flag'),
+        );
+        expect(
+          otelHook.capturedAttributes[0][OTelFeatureFlagConstants
+              .FLAG_VALUE_STRING],
+          equals('test-value'),
+        );
+      },
+    );
+
+    test('includes error reason when appropriate', () async {
+      final otelHook = OTelTestHook(providerName: 'test-provider');
+
+      await otelHook.finally_(
+        HookContext(
+          flagKey: 'test-flag',
+          result: null,
+          error: Exception('Test error'),
+        ),
+        null,
+      );
+
+      expect(
+        otelHook.capturedAttributes[0][OTelFeatureFlagConstants.REASON],
+        equals(OTelFeatureFlagConstants.REASON_ERROR),
       );
     });
   });


### PR DESCRIPTION
## This PR

- Adds evaluation details parameter to the finally hook stage
- Implements OpenTelemetry-compatible telemetry utility functions

### Related Issues

- Fixes Add evaluation details to finally hook stage #27 
- Fixes Add OpenTelemetry-Compatible Telemetry Utility Function #26 

