### PR TITLE
chore: add provider fixes

### DIFF
--- a/lib/feature_provider.dart
+++ b/lib/feature_provider.dart
@@ -14,6 +14,30 @@ enum ProviderState {
   MAINTENANCE,
 }
 
+/// OpenFeature error codes
+enum ErrorCode {
+  FLAG_NOT_FOUND,
+  TYPE_MISMATCH,
+  GENERAL,
+  PARSE_ERROR,
+  TARGETING_KEY_MISSING,
+  INVALID_CONTEXT,
+  PROVIDER_NOT_READY,
+}
+
+/// Provider metadata
+class ProviderMetadata {
+  final String name;
+  final String version;
+  final Map<String, String> attributes;
+
+  const ProviderMetadata({
+    required this.name,
+    this.version = '1.0.0',
+    this.attributes = const {},
+  });
+}
+
 /// Provider configuration
 class ProviderConfig {
   final Duration connectionTimeout;
@@ -40,6 +64,9 @@ class FlagEvaluationResult<T> {
   final String flagKey;
   final T value;
   final String reason;
+  final String? variant;
+  final ErrorCode? errorCode;
+  final String? errorMessage;
   final Map<String, dynamic>? details;
   final DateTime evaluatedAt;
   final String evaluatorId;
@@ -48,26 +75,48 @@ class FlagEvaluationResult<T> {
     required this.flagKey,
     required this.value,
     this.reason = 'DEFAULT',
+    this.variant,
+    this.errorCode,
+    this.errorMessage,
     this.details,
     required this.evaluatedAt,
     this.evaluatorId = '',
   });
+
+  /// Create an error result
+  static FlagEvaluationResult<T> error<T>(
+    String flagKey,
+    T defaultValue,
+    ErrorCode errorCode,
+    String message, {
+    String evaluatorId = '',
+  }) {
+    return FlagEvaluationResult<T>(
+      flagKey: flagKey,
+      value: defaultValue,
+      reason: 'ERROR',
+      errorCode: errorCode,
+      errorMessage: message,
+      evaluatedAt: DateTime.now(),
+      evaluatorId: evaluatorId,
+    );
+  }
 }
 
 /// Provider exception
 class ProviderException implements Exception {
   final String message;
-  final String code;
+  final ErrorCode code;
   final Map<String, dynamic>? details;
 
   const ProviderException(
     this.message, {
-    this.code = 'PROVIDER_ERROR',
+    this.code = ErrorCode.GENERAL,
     this.details,
   });
 
   @override
-  String toString() => 'ProviderException: $message (code: $code)';
+  String toString() => 'ProviderException: $message (code: ${code.name})';
 }
 
 /// Feature provider interface
@@ -75,6 +124,7 @@ abstract class FeatureProvider {
   String get name;
   ProviderState get state;
   ProviderConfig get config;
+  ProviderMetadata get metadata;
 
   Future<void> initialize([Map<String, dynamic>? config]);
   Future<void> connect();
@@ -116,9 +166,11 @@ class InMemoryProvider implements FeatureProvider {
   final Map<String, dynamic> _flags;
   ProviderState _state = ProviderState.NOT_READY;
   final ProviderConfig _config;
+  final ProviderMetadata _metadata;
 
   InMemoryProvider(this._flags, [ProviderConfig? config])
-    : _config = config ?? const ProviderConfig();
+    : _config = config ?? const ProviderConfig(),
+      _metadata = const ProviderMetadata(name: 'InMemoryProvider');
 
   @override
   String get name => 'InMemoryProvider';
@@ -130,13 +182,47 @@ class InMemoryProvider implements FeatureProvider {
   ProviderConfig get config => _config;
 
   @override
+  ProviderMetadata get metadata => _metadata;
+
+  @override
   Future<void> initialize([Map<String, dynamic>? config]) async {
-    _state = ProviderState.READY;
+    if (_state == ProviderState.SHUTDOWN) {
+      throw ProviderException(
+        'Cannot initialize a shutdown provider',
+        code: ErrorCode.PROVIDER_NOT_READY,
+      );
+    }
+
+    _state = ProviderState.CONNECTING;
+
+    try {
+      // Simulate initialization work
+      await Future.delayed(Duration(milliseconds: 10));
+      _state = ProviderState.READY;
+    } catch (e) {
+      _state = ProviderState.ERROR;
+      rethrow;
+    }
   }
 
   @override
   Future<void> connect() async {
-    _state = ProviderState.READY;
+    if (_state == ProviderState.SHUTDOWN) {
+      throw ProviderException(
+        'Cannot connect a shutdown provider',
+        code: ErrorCode.PROVIDER_NOT_READY,
+      );
+    }
+
+    _state = ProviderState.CONNECTING;
+
+    try {
+      await Future.delayed(Duration(milliseconds: 10));
+      _state = ProviderState.READY;
+    } catch (e) {
+      _state = ProviderState.ERROR;
+      rethrow;
+    }
   }
 
   @override
@@ -147,9 +233,9 @@ class InMemoryProvider implements FeatureProvider {
   void _checkState() {
     if (_state != ProviderState.READY) {
       throw ProviderException(
-        'Provider not in READY state',
-        code: 'PROVIDER_NOT_READY',
-        details: {'currentState': _state.toString()},
+        'Provider not in READY state: ${_state.name}',
+        code: ErrorCode.PROVIDER_NOT_READY,
+        details: {'currentState': _state.name},
       );
     }
   }
@@ -161,10 +247,32 @@ class InMemoryProvider implements FeatureProvider {
     Map<String, dynamic>? context,
   }) async {
     _checkState();
-    final value = _flags[flagKey] ?? defaultValue;
+
+    if (!_flags.containsKey(flagKey)) {
+      return FlagEvaluationResult.error(
+        flagKey,
+        defaultValue,
+        ErrorCode.FLAG_NOT_FOUND,
+        'Flag "$flagKey" not found',
+        evaluatorId: name,
+      );
+    }
+
+    final value = _flags[flagKey];
+    if (value is! bool) {
+      return FlagEvaluationResult.error(
+        flagKey,
+        defaultValue,
+        ErrorCode.TYPE_MISMATCH,
+        'Flag "$flagKey" is not a boolean, got ${value.runtimeType}',
+        evaluatorId: name,
+      );
+    }
+
     return FlagEvaluationResult(
       flagKey: flagKey,
-      value: value is bool ? value : defaultValue,
+      value: value,
+      reason: 'STATIC',
       evaluatedAt: DateTime.now(),
       evaluatorId: name,
     );
@@ -177,10 +285,32 @@ class InMemoryProvider implements FeatureProvider {
     Map<String, dynamic>? context,
   }) async {
     _checkState();
-    final value = _flags[flagKey] ?? defaultValue;
+
+    if (!_flags.containsKey(flagKey)) {
+      return FlagEvaluationResult.error(
+        flagKey,
+        defaultValue,
+        ErrorCode.FLAG_NOT_FOUND,
+        'Flag "$flagKey" not found',
+        evaluatorId: name,
+      );
+    }
+
+    final value = _flags[flagKey];
+    if (value is! String) {
+      return FlagEvaluationResult.error(
+        flagKey,
+        defaultValue,
+        ErrorCode.TYPE_MISMATCH,
+        'Flag "$flagKey" is not a string, got ${value.runtimeType}',
+        evaluatorId: name,
+      );
+    }
+
     return FlagEvaluationResult(
       flagKey: flagKey,
-      value: value is String ? value : defaultValue,
+      value: value,
+      reason: 'STATIC',
       evaluatedAt: DateTime.now(),
       evaluatorId: name,
     );
@@ -193,10 +323,32 @@ class InMemoryProvider implements FeatureProvider {
     Map<String, dynamic>? context,
   }) async {
     _checkState();
-    final value = _flags[flagKey] ?? defaultValue;
+
+    if (!_flags.containsKey(flagKey)) {
+      return FlagEvaluationResult.error(
+        flagKey,
+        defaultValue,
+        ErrorCode.FLAG_NOT_FOUND,
+        'Flag "$flagKey" not found',
+        evaluatorId: name,
+      );
+    }
+
+    final value = _flags[flagKey];
+    if (value is! int) {
+      return FlagEvaluationResult.error(
+        flagKey,
+        defaultValue,
+        ErrorCode.TYPE_MISMATCH,
+        'Flag "$flagKey" is not an integer, got ${value.runtimeType}',
+        evaluatorId: name,
+      );
+    }
+
     return FlagEvaluationResult(
       flagKey: flagKey,
-      value: value is int ? value : defaultValue,
+      value: value,
+      reason: 'STATIC',
       evaluatedAt: DateTime.now(),
       evaluatorId: name,
     );
@@ -209,10 +361,32 @@ class InMemoryProvider implements FeatureProvider {
     Map<String, dynamic>? context,
   }) async {
     _checkState();
-    final value = _flags[flagKey] ?? defaultValue;
+
+    if (!_flags.containsKey(flagKey)) {
+      return FlagEvaluationResult.error(
+        flagKey,
+        defaultValue,
+        ErrorCode.FLAG_NOT_FOUND,
+        'Flag "$flagKey" not found',
+        evaluatorId: name,
+      );
+    }
+
+    final value = _flags[flagKey];
+    if (value is! double) {
+      return FlagEvaluationResult.error(
+        flagKey,
+        defaultValue,
+        ErrorCode.TYPE_MISMATCH,
+        'Flag "$flagKey" is not a double, got ${value.runtimeType}',
+        evaluatorId: name,
+      );
+    }
+
     return FlagEvaluationResult(
       flagKey: flagKey,
-      value: value is double ? value : defaultValue,
+      value: value,
+      reason: 'STATIC',
       evaluatedAt: DateTime.now(),
       evaluatorId: name,
     );
@@ -225,10 +399,32 @@ class InMemoryProvider implements FeatureProvider {
     Map<String, dynamic>? context,
   }) async {
     _checkState();
-    final value = _flags[flagKey] ?? defaultValue;
+
+    if (!_flags.containsKey(flagKey)) {
+      return FlagEvaluationResult.error(
+        flagKey,
+        defaultValue,
+        ErrorCode.FLAG_NOT_FOUND,
+        'Flag "$flagKey" not found',
+        evaluatorId: name,
+      );
+    }
+
+    final value = _flags[flagKey];
+    if (value is! Map<String, dynamic>) {
+      return FlagEvaluationResult.error(
+        flagKey,
+        defaultValue,
+        ErrorCode.TYPE_MISMATCH,
+        'Flag "$flagKey" is not an object, got ${value.runtimeType}',
+        evaluatorId: name,
+      );
+    }
+
     return FlagEvaluationResult(
       flagKey: flagKey,
-      value: value is Map<String, dynamic> ? value : defaultValue,
+      value: value,
+      reason: 'STATIC',
       evaluatedAt: DateTime.now(),
       evaluatorId: name,
     );
@@ -242,19 +438,28 @@ abstract class CommercialProvider implements FeatureProvider {
   final Map<String, String> headers;
   final Duration timeout;
   ProviderState _state = ProviderState.NOT_READY;
+  final ProviderMetadata _metadata;
 
   CommercialProvider({
     required this.providerName,
     required this.baseUrl,
     this.headers = const {},
     this.timeout = const Duration(seconds: 5),
-  });
+  }) : _metadata = ProviderMetadata(name: providerName);
 
   @override
   String get name => providerName;
 
   @override
   ProviderState get state => _state;
+
+  @override
+  ProviderMetadata get metadata => _metadata;
+
+  // Subclasses must implement proper state transitions
+  void setState(ProviderState newState) {
+    _state = newState;
+  }
 
   // HTTP request implementation template
 }

--- a/test/feature_provider_test.dart
+++ b/test/feature_provider_test.dart
@@ -2,6 +2,59 @@ import 'package:test/test.dart';
 import '../lib/feature_provider.dart';
 
 void main() {
+  group('ProviderMetadata', () {
+    test('creates with required name', () {
+      final metadata = ProviderMetadata(name: 'TestProvider');
+      expect(metadata.name, equals('TestProvider'));
+      expect(metadata.version, equals('1.0.0'));
+      expect(metadata.attributes, isEmpty);
+    });
+
+    test('creates with all parameters', () {
+      final metadata = ProviderMetadata(
+        name: 'TestProvider',
+        version: '2.0.0',
+        attributes: {'type': 'test'},
+      );
+      expect(metadata.name, equals('TestProvider'));
+      expect(metadata.version, equals('2.0.0'));
+      expect(metadata.attributes['type'], equals('test'));
+    });
+  });
+
+  group('FlagEvaluationResult', () {
+    test('creates successful result', () {
+      final result = FlagEvaluationResult(
+        flagKey: 'test-flag',
+        value: true,
+        reason: 'STATIC',
+        evaluatedAt: DateTime.now(),
+        evaluatorId: 'TestProvider',
+      );
+
+      expect(result.flagKey, equals('test-flag'));
+      expect(result.value, isTrue);
+      expect(result.reason, equals('STATIC'));
+      expect(result.errorCode, isNull);
+    });
+
+    test('creates error result', () {
+      final result = FlagEvaluationResult.error(
+        'missing-flag',
+        false,
+        ErrorCode.FLAG_NOT_FOUND,
+        'Flag not found',
+        evaluatorId: 'TestProvider',
+      );
+
+      expect(result.flagKey, equals('missing-flag'));
+      expect(result.value, isFalse);
+      expect(result.reason, equals('ERROR'));
+      expect(result.errorCode, equals(ErrorCode.FLAG_NOT_FOUND));
+      expect(result.errorMessage, equals('Flag not found'));
+    });
+  });
+
   group('ProviderConfig', () {
     test('creates with default values', () {
       final config = ProviderConfig();
@@ -18,60 +71,110 @@ void main() {
       'string-flag': 'test',
       'int-flag': 42,
       'double-flag': 3.14,
-      'object-flag': {'key': 'value'}
+      'object-flag': {'key': 'value'},
     };
 
     setUp(() {
       provider = InMemoryProvider(testFlags);
-      provider.initialize();
+    });
+
+    test('has required metadata', () {
+      expect(provider.metadata.name, equals('InMemoryProvider'));
+      expect(provider.name, equals('InMemoryProvider'));
     });
 
     test('lifecycle state management', () async {
+      expect(provider.state, equals(ProviderState.NOT_READY));
+
+      await provider.initialize();
       expect(provider.state, equals(ProviderState.READY));
+
       await provider.shutdown();
       expect(provider.state, equals(ProviderState.SHUTDOWN));
     });
 
     test('throws when not ready', () async {
-      await provider.shutdown();
       expect(
         () => provider.getBooleanFlag('test', false),
         throwsA(isA<ProviderException>()),
       );
     });
 
-    group('flag evaluation', () {
-      test('evaluates boolean flag', () async {
+    test('prevents initialization after shutdown', () async {
+      await provider.shutdown();
+      expect(() => provider.initialize(), throwsA(isA<ProviderException>()));
+    });
+
+    group('flag evaluation when ready', () {
+      setUp(() async {
+        await provider.initialize();
+      });
+
+      test('evaluates existing boolean flag', () async {
         final result = await provider.getBooleanFlag('bool-flag', false);
         expect(result.value, isTrue);
         expect(result.flagKey, equals('bool-flag'));
         expect(result.evaluatorId, equals('InMemoryProvider'));
+        expect(result.reason, equals('STATIC'));
+        expect(result.errorCode, isNull);
       });
 
-      test('returns default for missing boolean flag', () async {
+      test('returns error for missing boolean flag', () async {
         final result = await provider.getBooleanFlag('missing-flag', true);
-        expect(result.value, isTrue);
+        expect(result.value, isTrue); // default value
+        expect(result.errorCode, equals(ErrorCode.FLAG_NOT_FOUND));
+        expect(result.reason, equals('ERROR'));
+        expect(result.errorMessage, contains('not found'));
+      });
+
+      test('returns error for type mismatch', () async {
+        final result = await provider.getBooleanFlag('string-flag', false);
+        expect(result.value, isFalse); // default value
+        expect(result.errorCode, equals(ErrorCode.TYPE_MISMATCH));
+        expect(result.reason, equals('ERROR'));
+        expect(result.errorMessage, contains('not a boolean'));
       });
 
       test('evaluates string flag', () async {
         final result = await provider.getStringFlag('string-flag', '');
         expect(result.value, equals('test'));
+        expect(result.errorCode, isNull);
       });
 
       test('evaluates integer flag', () async {
         final result = await provider.getIntegerFlag('int-flag', 0);
         expect(result.value, equals(42));
+        expect(result.errorCode, isNull);
       });
 
       test('evaluates double flag', () async {
         final result = await provider.getDoubleFlag('double-flag', 0.0);
         expect(result.value, equals(3.14));
+        expect(result.errorCode, isNull);
       });
 
       test('evaluates object flag', () async {
         final result = await provider.getObjectFlag('object-flag', {});
         expect(result.value, equals({'key': 'value'}));
+        expect(result.errorCode, isNull);
       });
+    });
+  });
+
+  group('ProviderException', () {
+    test('creates with message and default code', () {
+      final exception = ProviderException('Test error');
+      expect(exception.message, equals('Test error'));
+      expect(exception.code, equals(ErrorCode.GENERAL));
+    });
+
+    test('creates with specific error code', () {
+      final exception = ProviderException(
+        'Not ready',
+        code: ErrorCode.PROVIDER_NOT_READY,
+      );
+      expect(exception.code, equals(ErrorCode.PROVIDER_NOT_READY));
+      expect(exception.toString(), contains('PROVIDER_NOT_READY'));
     });
   });
 }


### PR DESCRIPTION
## This PR

- Adds required ProviderMetadata getter with name field to FeatureProvider interface
- Implements proper FlagEvaluationResult construction with variant, errorCode, errorMessage fields
- Adds OpenFeature-compliant state transitions: NOT_READY → CONNECTING → READY → SHUTDOWN
- Implements standardized error codes: FLAG_NOT_FOUND, TYPE_MISMATCH, GENERAL, PROVIDER_NOT_READY
- Updates InMemoryProvider to return proper error results instead of silent fallbacks


