### PR TITLE
chore: fix provider not in ready state

### DIFF
--- a/lib/feature_provider.dart
+++ b/lib/feature_provider.dart
@@ -205,9 +205,6 @@ abstract class CachedFeatureProvider implements FeatureProvider {
   ProviderMetadata get metadata => _metadata;
 
   @override
-  ProviderMetadata get metadata => _metadata;
-
-  @override
   String get name => _metadata.name;
 
   /// Set provider state

--- a/lib/open_feature_api.dart
+++ b/lib/open_feature_api.dart
@@ -139,210 +139,9 @@ class _ImmediateReadyProvider implements FeatureProvider {
   }
 }
 
-/// Default provider that's immediately ready - completely independent
-class _ImmediateReadyProvider implements FeatureProvider {
-  @override
-  String get name => 'InMemoryProvider';
-
-  @override
-  ProviderState get state => ProviderState.READY;
-
-  @override
-  ProviderConfig get config => const ProviderConfig();
-
-  @override
-  ProviderMetadata get metadata =>
-      const ProviderMetadata(name: 'InMemoryProvider');
-
-  @override
-  Future<void> initialize([Map<String, dynamic>? config]) async {}
-
-  @override
-  Future<void> connect() async {}
-
-  @override
-  Future<void> shutdown() async {}
-
-  @override
-  Future<FlagEvaluationResult<bool>> getBooleanFlag(
-    String flagKey,
-    bool defaultValue, {
-    Map<String, dynamic>? context,
-  }) async {
-    return FlagEvaluationResult.error(
-      flagKey,
-      defaultValue,
-      ErrorCode.FLAG_NOT_FOUND,
-      'Flag not found',
-      evaluatorId: name,
-    );
-  }
-
-  @override
-  Future<FlagEvaluationResult<String>> getStringFlag(
-    String flagKey,
-    String defaultValue, {
-    Map<String, dynamic>? context,
-  }) async {
-    return FlagEvaluationResult.error(
-      flagKey,
-      defaultValue,
-      ErrorCode.FLAG_NOT_FOUND,
-      'Flag not found',
-      evaluatorId: name,
-    );
-  }
-
-  @override
-  Future<FlagEvaluationResult<int>> getIntegerFlag(
-    String flagKey,
-    int defaultValue, {
-    Map<String, dynamic>? context,
-  }) async {
-    return FlagEvaluationResult.error(
-      flagKey,
-      defaultValue,
-      ErrorCode.FLAG_NOT_FOUND,
-      'Flag not found',
-      evaluatorId: name,
-    );
-  }
-
-  @override
-  Future<FlagEvaluationResult<double>> getDoubleFlag(
-    String flagKey,
-    double defaultValue, {
-    Map<String, dynamic>? context,
-  }) async {
-    return FlagEvaluationResult.error(
-      flagKey,
-      defaultValue,
-      ErrorCode.FLAG_NOT_FOUND,
-      'Flag not found',
-      evaluatorId: name,
-    );
-  }
-
-  @override
-  Future<FlagEvaluationResult<Map<String, dynamic>>> getObjectFlag(
-    String flagKey,
-    Map<String, dynamic> defaultValue, {
-    Map<String, dynamic>? context,
-  }) async {
-    return FlagEvaluationResult.error(
-      flagKey,
-      defaultValue,
-      ErrorCode.FLAG_NOT_FOUND,
-      'Flag not found',
-      evaluatorId: name,
-    );
-  }
-}
-
-/// Default provider that's immediately ready - completely independent
-class _ImmediateReadyProvider implements FeatureProvider {
-  @override
-  String get name => 'InMemoryProvider';
-
-  @override
-  ProviderState get state => ProviderState.READY;
-
-  @override
-  ProviderConfig get config => const ProviderConfig();
-
-  @override
-  ProviderMetadata get metadata =>
-      const ProviderMetadata(name: 'InMemoryProvider');
-
-  @override
-  Future<void> initialize([Map<String, dynamic>? config]) async {}
-
-  @override
-  Future<void> connect() async {}
-
-  @override
-  Future<void> shutdown() async {}
-
-  @override
-  Future<FlagEvaluationResult<bool>> getBooleanFlag(
-    String flagKey,
-    bool defaultValue, {
-    Map<String, dynamic>? context,
-  }) async {
-    return FlagEvaluationResult.error(
-      flagKey,
-      defaultValue,
-      ErrorCode.FLAG_NOT_FOUND,
-      'Flag not found',
-      evaluatorId: name,
-    );
-  }
-
-  @override
-  Future<FlagEvaluationResult<String>> getStringFlag(
-    String flagKey,
-    String defaultValue, {
-    Map<String, dynamic>? context,
-  }) async {
-    return FlagEvaluationResult.error(
-      flagKey,
-      defaultValue,
-      ErrorCode.FLAG_NOT_FOUND,
-      'Flag not found',
-      evaluatorId: name,
-    );
-  }
-
-  @override
-  Future<FlagEvaluationResult<int>> getIntegerFlag(
-    String flagKey,
-    int defaultValue, {
-    Map<String, dynamic>? context,
-  }) async {
-    return FlagEvaluationResult.error(
-      flagKey,
-      defaultValue,
-      ErrorCode.FLAG_NOT_FOUND,
-      'Flag not found',
-      evaluatorId: name,
-    );
-  }
-
-  @override
-  Future<FlagEvaluationResult<double>> getDoubleFlag(
-    String flagKey,
-    double defaultValue, {
-    Map<String, dynamic>? context,
-  }) async {
-    return FlagEvaluationResult.error(
-      flagKey,
-      defaultValue,
-      ErrorCode.FLAG_NOT_FOUND,
-      'Flag not found',
-      evaluatorId: name,
-    );
-  }
-
-  @override
-  Future<FlagEvaluationResult<Map<String, dynamic>>> getObjectFlag(
-    String flagKey,
-    Map<String, dynamic> defaultValue, {
-    Map<String, dynamic>? context,
-  }) async {
-    return FlagEvaluationResult.error(
-      flagKey,
-      defaultValue,
-      ErrorCode.FLAG_NOT_FOUND,
-      'Flag not found',
-      evaluatorId: name,
-    );
-  }
-}
-
 class OpenFeatureAPI {
   static final Logger _logger = Logger('OpenFeatureAPI');
   static OpenFeatureAPI? _instance;
-  static bool _testMode = false; // Add test mode flag
 
   late FeatureProvider _provider;
   final DomainManager _domainManager = DomainManager();
@@ -363,45 +162,17 @@ class OpenFeatureAPI {
   }
 
   factory OpenFeatureAPI() {
-    // In test mode, always return new instance
-    if (_testMode) {
-      return OpenFeatureAPI._internal();
-    }
-
     _instance ??= OpenFeatureAPI._internal();
     return _instance!;
   }
 
-  // Enable test mode - disables singleton
-  static void enableTestMode() {
-    _testMode = true;
-    _instance = null;
-  }
-
-  // Disable test mode - re-enables singleton
-  static void disableTestMode() {
-    _testMode = false;
-    _instance = null;
-  }
-
-  // Public constructor for testing - bypasses singleton
-  factory OpenFeatureAPI.forTesting() {
-    return OpenFeatureAPI._internal();
-  }
-
-  static bool _loggingConfigured = false;
-
   void _configureLogging() {
-    // Only configure logging once globally to prevent multiple listeners
-    if (!_loggingConfigured) {
-      Logger.root.level = Level.ALL;
-      Logger.root.onRecord.listen((record) {
-        print(
-          '${record.time} [${record.level.name}] ${record.loggerName}: ${record.message}',
-        );
-      });
-      _loggingConfigured = true;
-    }
+    Logger.root.level = Level.ALL;
+    Logger.root.onRecord.listen((record) {
+      print(
+        '${record.time} [${record.level.name}] ${record.loggerName}: ${record.message}',
+      );
+    });
   }
 
   void _initializeDefaultProvider() {
@@ -569,18 +340,8 @@ class OpenFeatureAPI {
     await _domainUpdatesController.close();
   }
 
-  // FIXED: Proper singleton reset with complete cleanup
   static void resetInstance() {
-    if (_instance != null) {
-      try {
-        _instance!._providerStreamController.close();
-        _instance!._eventStreamController.close();
-        _instance!._domainUpdatesController.close();
-        _instance!._domainManager.dispose();
-      } catch (e) {
-        // Ignore disposal errors during reset
-      }
-    }
+    _instance?.dispose();
     _instance = null;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,21 +16,21 @@ version: 0.0.12
 
 homepage: https://github.com/open-feature/dart-server-sdk
 environment:
-  sdk: ^3.9.2
+  sdk: ^3.9.3
 
 dependencies:
-# Core dependencies
-  collection: ^1.19.1   # For efficient list and map operations
-  logging: ^1.3.0       # For structured logging
-  meta: ^1.17.0         # For annotations like @required
+  # Core dependencies
+  collection: ^1.19.1 # For efficient list and map operations
+  logging: ^1.3.0 # For structured logging
+  meta: ^1.17.0 # For annotations like @required
 
 dev_dependencies:
-# For testing
-  coverage: ^1.15.0     # For Code Coverage Reports
-  git_hooks: ^1.0.2     # Provides hooks for locla ddevelopment
-  lints: ^6.0.0         # Recommended lints for maintaining code quality
-  mockito: ^5.5.0       # For mocking objects in unit tests
-  test: ^1.26.3        # Dart's core testing framework
+  # For testing
+  coverage: ^1.15.0 # For Code Coverage Reports
+  git_hooks: ^1.0.2 # Provides hooks for locla ddevelopment
+  lints: ^6.0.0 # Recommended lints for maintaining code quality
+  mockito: ^5.5.0 # For mocking objects in unit tests
+  test: ^1.26.3 # Dart's core testing framework
 
 # Optional Local Hooks for development.
 git_hooks:


### PR DESCRIPTION
## This PR

- Added `_ImmediateReadyProvider` as default provider (already READY, no initialization delay)
- Fixed `setProvider()` to await provider initialization before completing, preventing race conditions
- Added state checks in `evaluateBooleanFlag()` to short-circuit when provider not READY
- Updated error handling to keep providers in ERROR state per OpenFeature specification




