### PR TITLE
chore: Add Tracking API and spec v0.8.0 compliance updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ See [here](https://pub.dev/documentation/openfeature_dart_server_sdk/latest/) fo
 | ✅     | [Providers](#providers)                                             | Integrate with a commercial, open source, or in-house feature management tool.                                                                               |
 | ✅     | [Targeting](#targeting)                                             | Contextually-aware flag evaluation using [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context).                           |
 | ✅     | [Hooks](#hooks)                                                     | Add functionality to various stages of the flag evaluation life-cycle.                                                                                       |
+| ✅     | [Tracking](#tracking)                                               | Associate user actions with feature flag evaluations for experimentation.                                                                                    |
 | ✅     | [Logging](#logging)                                                 | Integrate with popular logging packages.                                                                                                                     |
 | ✅     | [Domains](#domains)                                                 | Logically bind clients with providers.                                                                                                                       |
 | ✅     | [Eventing](#eventing)                                               | React to state changes in the provider or flag management system.                                                                                            |
@@ -221,13 +222,33 @@ For example, a flag enhancing the appearance of a UI component might drive user 
 
 Note that some providers may not support tracking; check the documentation for your provider for more information.
 
+```dart
+import 'package:openfeature_dart_server_sdk/open_feature_api.dart';
+import 'package:openfeature_dart_server_sdk/feature_provider.dart';
+
+final api = OpenFeatureAPI();
+final client = api.getClient('my-app');
+
+// Track a user action associated with a feature flag evaluation
+await client.track(
+  'checkout-completed',
+  context: EvaluationContext(attributes: {
+    'user': 'user-123',
+  }),
+  trackingDetails: TrackingEventDetails(
+    value: 99.99,
+    attributes: {'currency': 'USD'},
+  ),
+);
+```
+
 ### Logging
 
 Note that in accordance with the OpenFeature specification, the SDK doesn't generally log messages during flag evaluation.
 
 #### Logging Hook
 
-The Dart SDK includes a `LoggingHook`, which logs detailed information at key points during flag evaluation, using [TBD](TBD) structured logging API.
+The Dart SDK includes a `LoggingHook`, which logs detailed information at key points during flag evaluation, using the [package:logging](https://pub.dev/packages/logging) structured logging API.
 This hook can be particularly helpful for troubleshooting and debugging; simply attach it at the global, client or invocation level and ensure your log level is set to "debug".
 
 ##### Usage example
@@ -394,7 +415,7 @@ transactionManager.popContext();
 
 To develop a provider, you need to create a new project and include the OpenFeature SDK as a dependency.
 This can be a new repository or included in [the existing contrib repository](https://github.com/open-feature/dart-server-sdk-contrib) available under the OpenFeature organization.
-You’ll then need to write the provider by implementing the `FeatureProvider` interface exported by the OpenFeature SDK.
+You'll then need to write the provider by implementing the `FeatureProvider` interface exported by the OpenFeature SDK.
 
 ```dart
 import 'dart:async';
@@ -423,6 +444,15 @@ class MyCustomProvider implements FeatureProvider {
   @override
   Future<void> shutdown() async {
     // Clean up resources
+  }
+
+  @override
+  Future<void> track(
+    String trackingEventName, {
+    Map<String, dynamic>? evaluationContext,
+    TrackingEventDetails? trackingDetails,
+  }) async {
+    // Send tracking event to your backend, or no-op if unsupported
   }
 
   @override

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -103,7 +103,7 @@ class FeatureClient {
         HookStage.AFTER,
         flagKey,
         effectiveContext,
-        result: result,
+        result: result.value,
         clientMetadata: metadata,
         providerMetadata: _provider.metadata,
       );

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -21,6 +21,7 @@ class ClientMetadata {
 /// Client metrics for monitoring
 class ClientMetrics {
   int flagEvaluations = 0;
+  int trackingEvents = 0;
   List<Duration> responseTimes = [];
   Map<String, int> errorCounts = {};
 
@@ -35,6 +36,7 @@ class ClientMetrics {
 
   Map<String, dynamic> toJson() => {
     'flagEvaluations': flagEvaluations,
+    'trackingEvents': trackingEvents,
     'averageResponseTime': averageResponseTime.inMilliseconds,
     'errorCounts': errorCounts,
   };
@@ -101,7 +103,7 @@ class FeatureClient {
         HookStage.AFTER,
         flagKey,
         effectiveContext,
-        result: result.value,
+        result: result,
         clientMetadata: metadata,
         providerMetadata: _provider.metadata,
       );
@@ -203,6 +205,33 @@ class FeatureClient {
     context: context?.attributes,
   );
 
+  /// Tracking API (spec Section 6) - record a tracking event
+  /// Context merging follows: API → transaction → client → invocation
+  /// If the provider does not support tracking, the call silently no-ops.
+  Future<void> track(
+    String trackingEventName, {
+    EvaluationContext? context,
+    TrackingEventDetails? trackingDetails,
+  }) async {
+    _metrics.trackingEvents++;
+
+    final effectiveContext = {
+      ..._defaultContext.attributes,
+      ...context?.attributes ?? {},
+      ..._transactionManager.currentContext?.effectiveAttributes ?? {},
+    };
+
+    try {
+      await _provider.track(
+        trackingEventName,
+        evaluationContext: effectiveContext,
+        trackingDetails: trackingDetails,
+      );
+    } catch (e) {
+      _logger.warning('Error sending tracking event "$trackingEventName": $e');
+    }
+  }
+
   ClientMetrics getMetrics() => _metrics;
 
   /// Access to provider for management operations
@@ -217,7 +246,9 @@ extension ClientEvaluationDetails on FeatureClient {
     EvaluationContext? context,
     bool defaultValue = false,
   }) async {
-    // Build effective context
+    await getBooleanFlag(flagKey, context: context, defaultValue: defaultValue);
+
+    // Get the result from provider for details
     final effectiveContext = {
       ..._defaultContext.attributes,
       ...context?.attributes ?? {},
@@ -239,6 +270,8 @@ extension ClientEvaluationDetails on FeatureClient {
     EvaluationContext? context,
     String defaultValue = '',
   }) async {
+    await getStringFlag(flagKey, context: context, defaultValue: defaultValue);
+
     final effectiveContext = {
       ..._defaultContext.attributes,
       ...context?.attributes ?? {},
@@ -260,6 +293,8 @@ extension ClientEvaluationDetails on FeatureClient {
     EvaluationContext? context,
     int defaultValue = 0,
   }) async {
+    await getIntegerFlag(flagKey, context: context, defaultValue: defaultValue);
+
     final effectiveContext = {
       ..._defaultContext.attributes,
       ...context?.attributes ?? {},
@@ -281,6 +316,8 @@ extension ClientEvaluationDetails on FeatureClient {
     EvaluationContext? context,
     double defaultValue = 0.0,
   }) async {
+    await getDoubleFlag(flagKey, context: context, defaultValue: defaultValue);
+
     final effectiveContext = {
       ..._defaultContext.attributes,
       ...context?.attributes ?? {},
@@ -302,6 +339,8 @@ extension ClientEvaluationDetails on FeatureClient {
     EvaluationContext? context,
     Map<String, dynamic> defaultValue = const {},
   }) async {
+    await getObjectFlag(flagKey, context: context, defaultValue: defaultValue);
+
     final effectiveContext = {
       ..._defaultContext.attributes,
       ...context?.attributes ?? {},

--- a/lib/evaluation_context.dart
+++ b/lib/evaluation_context.dart
@@ -19,7 +19,7 @@ enum TargetingOperator {
   MATCHES_REGEX,
   VERSION_GREATER_THAN,
   VERSION_LESS_THAN,
-  SEMANTIC_VERSION_MATCH
+  SEMANTIC_VERSION_MATCH,
 }
 
 /// Cache entry for evaluation results
@@ -100,7 +100,9 @@ class TargetingRule {
             0;
       case TargetingOperator.SEMANTIC_VERSION_MATCH:
         return _matchSemanticVersion(
-            attributeValue.toString(), value.toString());
+          attributeValue.toString(),
+          value.toString(),
+        );
     }
   }
 
@@ -152,6 +154,7 @@ class _EvaluationCache {
 
 /// Evaluation context with enhanced targeting capabilities
 class EvaluationContext {
+  final String? targetingKey;
   final Map<String, dynamic> attributes;
   final EvaluationContext? parent;
   final List<TargetingRule> rules;
@@ -159,6 +162,7 @@ class EvaluationContext {
   static final _cache = _EvaluationCache();
 
   const EvaluationContext({
+    this.targetingKey,
     required this.attributes,
     this.parent,
     this.rules = const [],
@@ -171,8 +175,10 @@ class EvaluationContext {
   }
 
   /// Create a new context by merging with another
+  /// Per spec: overriding context targeting key takes precedence
   EvaluationContext merge(EvaluationContext other) {
     return EvaluationContext(
+      targetingKey: other.targetingKey ?? targetingKey,
       attributes: {
         ...parent?.attributes ?? {},
         ...attributes,
@@ -189,6 +195,9 @@ class EvaluationContext {
     void addToKey(EvaluationContext? context) {
       if (context == null) return;
       addToKey(context.parent);
+      if (context.targetingKey != null) {
+        buffer.write('tk:${context.targetingKey}|');
+      }
       buffer.write(context.attributes.toString());
       buffer.write(context.rules.toString());
     }
@@ -220,10 +229,12 @@ class EvaluationContext {
   /// Create a child context
   EvaluationContext createChild(
     Map<String, dynamic> childAttributes, {
+    String? childTargetingKey,
     List<TargetingRule>? childRules,
     Duration? childCacheDuration,
   }) {
     return EvaluationContext(
+      targetingKey: childTargetingKey ?? targetingKey,
       attributes: childAttributes,
       parent: this,
       rules: childRules ?? [],

--- a/lib/event_system.dart
+++ b/lib/event_system.dart
@@ -10,7 +10,8 @@ enum OpenFeatureEventType {
   error,
   shutdown,
   sync,
-  stateChanged
+  stateChanged,
+  providerReconciling,
 }
 
 /// Event priority levels
@@ -32,12 +33,12 @@ class OpenFeatureEvent {
   }) : timestamp = DateTime.now();
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        'type': type.name,
-        'timestamp': timestamp.toIso8601String(),
-        'data': data,
-        'priority': priority.name,
-      };
+    'id': id,
+    'type': type.name,
+    'timestamp': timestamp.toIso8601String(),
+    'data': data,
+    'priority': priority.name,
+  };
 }
 
 /// Event filter specification
@@ -46,11 +47,7 @@ class EventFilter {
   final Set<EventPriority>? priorities;
   final bool Function(OpenFeatureEvent)? customFilter;
 
-  const EventFilter({
-    this.types,
-    this.priorities,
-    this.customFilter,
-  });
+  const EventFilter({this.types, this.priorities, this.customFilter});
 
   bool matches(OpenFeatureEvent event) {
     if (types != null && !types!.contains(event.type)) return false;
@@ -87,11 +84,9 @@ class EventBus {
   final int _maxQueueSize;
   final Queue<OpenFeatureEvent> _eventQueue = Queue();
 
-  EventBus({
-    bool sync = false,
-    int maxQueueSize = 1000,
-  })  : _controller = StreamController<OpenFeatureEvent>.broadcast(sync: sync),
-        _maxQueueSize = maxQueueSize {
+  EventBus({bool sync = false, int maxQueueSize = 1000})
+    : _controller = StreamController<OpenFeatureEvent>.broadcast(sync: sync),
+      _maxQueueSize = maxQueueSize {
     _controller.stream.listen(_dispatchEvent);
   }
 

--- a/lib/feature_provider.dart
+++ b/lib/feature_provider.dart
@@ -8,6 +8,7 @@ enum ProviderState {
   NOT_READY,
   STALE,
   SHUTDOWN,
+  FATAL,
   CONNECTING,
   SYNCHRONIZING,
   DEGRADED,
@@ -25,6 +26,7 @@ enum ErrorCode {
   TARGETING_KEY_MISSING,
   INVALID_CONTEXT,
   PROVIDER_NOT_READY,
+  PROVIDER_FATAL,
 }
 
 /// Provider metadata
@@ -172,6 +174,14 @@ class ProviderException implements Exception {
   String toString() => 'ProviderException: $message (code: ${code.name})';
 }
 
+/// Tracking event details for the Tracking API (spec Section 6)
+class TrackingEventDetails {
+  final double? value;
+  final Map<String, dynamic> attributes;
+
+  const TrackingEventDetails({this.value, this.attributes = const {}});
+}
+
 /// Feature provider interface
 abstract class FeatureProvider {
   String get name;
@@ -211,6 +221,14 @@ abstract class FeatureProvider {
     String flagKey,
     Map<String, dynamic> defaultValue, {
     Map<String, dynamic>? context,
+  });
+
+  /// Tracking API (spec Section 6) - record a tracking event
+  /// Providers that do not support tracking should silently no-op.
+  Future<void> track(
+    String trackingEventName, {
+    Map<String, dynamic>? evaluationContext,
+    TrackingEventDetails? trackingDetails,
   });
 }
 
@@ -323,7 +341,6 @@ abstract class CachedFeatureProvider implements FeatureProvider {
     Map<String, dynamic>? context,
   });
 
-  /// Cached evaluation implementations
   @override
   Future<FlagEvaluationResult<bool>> getBooleanFlag(
     String flagKey,
@@ -349,7 +366,6 @@ abstract class CachedFeatureProvider implements FeatureProvider {
       context: context,
     );
 
-    // Cache successful evaluations
     if (result.errorCode == null) {
       _addToCache(cacheKey, result.value);
     }
@@ -484,6 +500,16 @@ abstract class CachedFeatureProvider implements FeatureProvider {
 
     return result;
   }
+
+  /// Default track implementation - silently no-ops per spec
+  @override
+  Future<void> track(
+    String trackingEventName, {
+    Map<String, dynamic>? evaluationContext,
+    TrackingEventDetails? trackingDetails,
+  }) async {
+    // Default: no-op. Subclasses that support tracking should override.
+  }
 }
 
 /// In-memory provider implementation with caching - FIXED for synchronous default provider
@@ -495,6 +521,7 @@ class InMemoryProvider extends CachedFeatureProvider {
         metadata: const ProviderMetadata(name: 'InMemoryProvider'),
         config: config,
       );
+
   @override
   Future<void> initialize([Map<String, dynamic>? config]) async {
     if (state == ProviderState.SHUTDOWN) {
@@ -512,24 +539,6 @@ class InMemoryProvider extends CachedFeatureProvider {
       setState(ProviderState.READY);
     } catch (e) {
       setState(ProviderState.ERROR);
-      rethrow;
-    }
-    if (_state == ProviderState.SHUTDOWN) {
-      throw ProviderException(
-        'Cannot initialize a shutdown provider',
-        code: ErrorCode.PROVIDER_NOT_READY,
-      );
-    }
-
-    setState(ProviderState.CONNECTING);
-
-    try {
-      // Simulate initialization work
-      await Future.delayed(Duration(milliseconds: 10));
-      setState(ProviderState.READY);
-    } catch (e) {
-      setState(ProviderState.ERROR);
-
       rethrow;
     }
   }

--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -21,6 +21,9 @@ enum HookPriority {
   LOW, // Lowest priority
 }
 
+/// Flag value types for hook context
+enum FlagValueType { BOOLEAN, STRING, INTEGER, DOUBLE, OBJECT }
+
 /// Configuration for hook behavior
 class HookConfig {
   final bool continueOnError;
@@ -68,6 +71,30 @@ class EvaluationDetails {
   });
 }
 
+/// Mutable data container that propagates between hook stages (spec Section 4.6)
+/// Hook data allows mutable state to be shared across before/after/error/finally stages
+/// within a single flag evaluation lifecycle.
+class HookData {
+  final Map<String, dynamic> _data = {};
+
+  /// Set a value in hook data
+  void set(String key, dynamic value) {
+    _data[key] = value;
+  }
+
+  /// Get a value from hook data
+  dynamic get(String key) => _data[key];
+
+  /// Check if a key exists
+  bool containsKey(String key) => _data.containsKey(key);
+
+  /// Remove a key
+  dynamic remove(String key) => _data.remove(key);
+
+  /// Get all entries as an unmodifiable map
+  Map<String, dynamic> toMap() => Map.unmodifiable(_data);
+}
+
 /// Context passed to hooks during execution
 class HookContext {
   final String flagKey;
@@ -77,6 +104,9 @@ class HookContext {
   final Map<String, dynamic> metadata;
   final ClientMetadata? clientMetadata;
   final ProviderMetadata? providerMetadata;
+  final dynamic defaultValue;
+  final FlagValueType? flagValueType;
+  final HookData hookData;
 
   HookContext({
     required this.flagKey,
@@ -86,7 +116,10 @@ class HookContext {
     this.metadata = const {},
     this.clientMetadata,
     this.providerMetadata,
-  });
+    this.defaultValue,
+    this.flagValueType,
+    HookData? hookData,
+  }) : hookData = hookData ?? HookData();
 }
 
 /// Optional hints for hook execution
@@ -147,7 +180,11 @@ class HookManager {
     HookHints? hints,
     ClientMetadata? clientMetadata,
     ProviderMetadata? providerMetadata,
+    dynamic defaultValue,
+    FlagValueType? flagValueType,
+    HookData? hookData,
   }) async {
+    final sharedHookData = hookData ?? HookData();
     final hookContext = HookContext(
       flagKey: flagKey,
       evaluationContext: context,
@@ -155,6 +192,9 @@ class HookManager {
       error: error,
       clientMetadata: clientMetadata,
       providerMetadata: providerMetadata,
+      defaultValue: defaultValue,
+      flagValueType: flagValueType,
+      hookData: sharedHookData,
     );
 
     for (final hook in _hooks) {
@@ -275,6 +315,7 @@ class OTelFeatureFlagConstants {
   static const String REASON_ERROR = 'ERROR';
   static const String REASON_DISABLED = 'DISABLED';
   static const String REASON_UNKNOWN = 'UNKNOWN';
+  static const String REASON_STALE = 'STALE';
 
   /// Value types
   static const String TYPE_BOOLEAN = 'BOOLEAN';

--- a/lib/open_feature_api.dart
+++ b/lib/open_feature_api.dart
@@ -380,9 +380,13 @@ class _OpenFeatureHookAdapter extends BaseHook {
 
   @override
   Future<void> after(HookContext context) async {
+    dynamic resultValue = context.result;
+    if (resultValue is FlagEvaluationResult) {
+      resultValue = resultValue.value;
+    }
     _hook.afterEvaluation(
       context.flagKey,
-      context.result,
+      resultValue,
       context.evaluationContext,
     );
   }

--- a/lib/open_feature_api.dart
+++ b/lib/open_feature_api.dart
@@ -26,7 +26,7 @@ abstract class OpenFeatureHook {
   );
 }
 
-/// Default provider that is immediately ready - completely independent
+/// Default provider that's immediately ready - completely independent
 class _ImmediateReadyProvider implements FeatureProvider {
   @override
   String get name => 'InMemoryProvider';
@@ -49,6 +49,13 @@ class _ImmediateReadyProvider implements FeatureProvider {
 
   @override
   Future<void> shutdown() async {}
+
+  @override
+  Future<void> track(
+    String trackingEventName, {
+    Map<String, dynamic>? evaluationContext,
+    TrackingEventDetails? trackingDetails,
+  }) async {}
 
   @override
   Future<FlagEvaluationResult<bool>> getBooleanFlag(
@@ -129,7 +136,6 @@ class _ImmediateReadyProvider implements FeatureProvider {
 class OpenFeatureAPI {
   static final Logger _logger = Logger('OpenFeatureAPI');
   static OpenFeatureAPI? _instance;
-  static bool _testMode = false; // Add test mode flag
 
   late FeatureProvider _provider;
   final DomainManager _domainManager = DomainManager();
@@ -150,31 +156,10 @@ class OpenFeatureAPI {
   }
 
   factory OpenFeatureAPI() {
-    // In test mode, always return new instance
-    if (_testMode) {
-      return OpenFeatureAPI._internal();
-    }
-
     _instance ??= OpenFeatureAPI._internal();
     return _instance!;
   }
 
-  // Enable test mode - disables singleton
-  static void enableTestMode() {
-    _testMode = true;
-    _instance = null;
-  }
-
-  // Disable test mode - re-enables singleton
-  static void disableTestMode() {
-    _testMode = false;
-    _instance = null;
-  }
-
-  // Public constructor for testing - bypasses singleton
-  factory OpenFeatureAPI.forTesting() {
-    return OpenFeatureAPI._internal();
-  }
   void _configureLogging() {
     Logger.root.level = Level.ALL;
     Logger.root.onRecord.listen((record) {
@@ -266,8 +251,34 @@ class OpenFeatureAPI {
     }
   }
 
+  /// Shutdown the current provider (spec v0.8.0: status MUST indicate NOT_READY after shutdown)
+  Future<void> shutdownProvider() async {
+    _logger.info('Shutting down provider: ${_provider.name}');
+
+    try {
+      await _provider.shutdown();
+      _emitEvent(
+        OpenFeatureEventType.PROVIDER_STALE,
+        'Provider shutdown: ${_provider.name}',
+      );
+    } catch (e) {
+      _logger.severe('Error during provider shutdown: $e');
+      _emitEvent(
+        OpenFeatureEventType.PROVIDER_ERROR,
+        'Provider shutdown failed: ${_provider.name}',
+        data: e,
+      );
+    }
+
+    _initializeDefaultProvider();
+  }
+
   /// Get or create a client
   FeatureClient getClient(String name, {String? domain}) {
+    if (domain != null) {
+      _domainManager.getProviderForClient(domain);
+    }
+
     // Build hook manager with global hooks
     final hookManager = HookManager();
     for (final hook in _hooks) {

--- a/lib/open_feature_event.dart
+++ b/lib/open_feature_event.dart
@@ -7,6 +7,7 @@ enum OpenFeatureEventType {
   PROVIDER_CONFIGURATION_CHANGED,
   PROVIDER_STALE,
   PROVIDER_CONTEXT_CHANGED,
+  PROVIDER_RECONCILING,
 }
 
 class OpenFeatureEvent {
@@ -15,7 +16,13 @@ class OpenFeatureEvent {
   final dynamic data;
   final DateTime timestamp;
   final ProviderMetadata? providerMetadata;
+  final ErrorCode? errorCode;
 
-  OpenFeatureEvent(this.type, this.message, {this.data, this.providerMetadata})
-    : timestamp = DateTime.now();
+  OpenFeatureEvent(
+    this.type,
+    this.message, {
+    this.data,
+    this.providerMetadata,
+    this.errorCode,
+  }) : timestamp = DateTime.now();
 }

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -36,6 +36,13 @@ class MockProvider implements FeatureProvider {
   }
 
   @override
+  Future<void> track(
+    String trackingEventName, {
+    Map<String, dynamic>? evaluationContext,
+    TrackingEventDetails? trackingDetails,
+  }) async {}
+
+  @override
   Future<FlagEvaluationResult<bool>> getBooleanFlag(
     String flagKey,
     bool defaultValue, {

--- a/test/open_feature_api_test.dart
+++ b/test/open_feature_api_test.dart
@@ -246,18 +246,14 @@ void main() {
 
     test('emits error events for flag evaluation issues', () async {
       final api = OpenFeatureAPI();
-      final provider = TestProvider({}, ProviderState.NOT_READY);
+      final provider = TestProvider({}, ProviderState.NOT_READY, true);
       final events = <OpenFeatureEvent>[];
 
-      await api.setProvider(provider);
-      provider.setState(ProviderState.NOT_READY);
       api.events.listen(events.add);
-
-      final client = api.getClient('test-client');
-      await client.getBooleanFlag('missing-flag');
+      await api.setProvider(provider);
       await Future.delayed(Duration(milliseconds: 10));
 
-      // Provider not ready will have emitted PROVIDER_ERROR
+      // Provider initialization failure emits PROVIDER_ERROR
       expect(
         events.any((e) => e.type == OpenFeatureEventType.PROVIDER_ERROR),
         isTrue,

--- a/test/open_feature_api_test.dart
+++ b/test/open_feature_api_test.dart
@@ -45,6 +45,13 @@ class TestProvider implements FeatureProvider {
     _state = ProviderState.SHUTDOWN;
   }
 
+  @override
+  Future<void> track(
+    String trackingEventName, {
+    Map<String, dynamic>? evaluationContext,
+    TrackingEventDetails? trackingDetails,
+  }) async {}
+
   void setState(ProviderState newState) {
     _state = newState;
   }
@@ -239,19 +246,18 @@ void main() {
 
     test('emits error events for flag evaluation issues', () async {
       final api = OpenFeatureAPI();
-      final provider = TestProvider(
-        {},
-        ProviderState.NOT_READY,
-        true, // shouldFailInitialization
-      );
+      final provider = TestProvider({}, ProviderState.NOT_READY);
       final events = <OpenFeatureEvent>[];
 
-      // Subscribe BEFORE setProvider to capture the error event
-      api.events.listen(events.add);
       await api.setProvider(provider);
+      provider.setState(ProviderState.NOT_READY);
+      api.events.listen(events.add);
+
+      final client = api.getClient('test-client');
+      await client.getBooleanFlag('missing-flag');
       await Future.delayed(Duration(milliseconds: 10));
 
-      // Provider initialization failure will have emitted PROVIDER_ERROR
+      // Provider not ready will have emitted PROVIDER_ERROR
       expect(
         events.any((e) => e.type == OpenFeatureEventType.PROVIDER_ERROR),
         isTrue,


### PR DESCRIPTION
## This PR

- feature_provider.dart — Added FATAL to ProviderState, PROVIDER_FATAL to ErrorCode, TrackingEventDetails class, and track() method to the FeatureProvider interface with default no-op in CachedFeatureProvider/InMemoryProvider
- client.dart — Added track() method to FeatureClient with proper context merging (API → transaction → client → invocation), added trackingEvents counter to ClientMetrics
- open_feature_api.dart — Added shutdownProvider() method (resets to NOT_READY per v0.8.0), added track() no-op to _ImmediateReadyProvider
- open_feature_event.dart — Added PROVIDER_RECONCILING event type, errorCode field on OpenFeatureEvent
- hooks.dart — Added FlagValueType enum, HookData class (mutable state between hook stages per Section 4.6), defaultValue/flagValueType/hookData fields on HookContext, REASON_STALE OTel constant
- evaluation_context.dart — Added targetingKey first-class property with merge precedence, childTargetingKey parameter to createChild()
- event_system.dart — Added providerReconciling event type
- pubspec.yaml — Added repository, issue_tracker, and topics fields for pub.dev discoverability