### PR TITLE
docs: fix inaccuracies in README code examples and descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,6 @@ See [hooks](#hooks) for more information on adding custom logging behavior via h
 Clients can be assigned to a domain. A domain is a logical identifier that can be used to associate clients with a particular provider. If a domain has no associated provider, the default provider is used.
 
 ```dart
-import 'package:openfeature_dart_server_sdk/domain_manager.dart';
 import 'package:openfeature_dart_server_sdk/feature_provider.dart';
 import 'package:openfeature_dart_server_sdk/open_feature_api.dart';
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ See [hooks](#hooks) for more information on adding custom logging behavior via h
 Clients can be assigned to a domain. A domain is a logical identifier that can be used to associate clients with a particular provider. If a domain has no associated provider, the default provider is used.
 
 ```dart
+import 'package:openfeature_dart_server_sdk/domain_manager.dart';
 import 'package:openfeature_dart_server_sdk/feature_provider.dart';
 import 'package:openfeature_dart_server_sdk/open_feature_api.dart';
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ final result = await client.getBooleanFlag(
 Look [here](https://openfeature.dev/ecosystem/?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Hook&instant_search%5BrefinementList%5D%5Btechnology%5D%5B0%5D=Dart) for a complete list of available hooks.
 If the hook you're looking for hasn't been created yet, see the [develop a hook](#develop-a-hook) section to learn how to build it yourself.
 
-Once you've added a hook as a dependency, it can be registered at the global, client, or flag invocation level.
+Once you've added a hook as a dependency, it can be registered at the global or client level.
 
 ```dart
 // Add a hook globally, to run on all evaluations
@@ -269,17 +269,16 @@ final api = OpenFeatureAPI();
 // Register the default provider
 api.setProvider(InMemoryProvider({'default-flag': true}));
 
-// Register a domain-specific provider
+// Register a domain-specific provider binding
 api.bindClientToProvider('cache-domain', 'CachedProvider');
 
-// Client backed by default provider
-final defaultClient = api.getClient('default-client');
-await defaultClient.getBooleanFlag('my-flag', defaultValue: false);
-
-// Client backed by CachedProvider
-final cacheClient = api.getClient('cache-client', domain: 'cache-domain');
-await cacheClient.getBooleanFlag('my-flag', defaultValue: false);
+// Create a client (uses the default provider)
+final client = api.getClient('my-client');
+await client.getBooleanFlag('my-flag', defaultValue: false);
 ```
+
+> [!NOTE]
+> Domain-to-provider bindings can be registered via `bindClientToProvider`, but `getClient` does not yet resolve domain-specific provider instances. All clients currently use the default provider.
 
 ### Eventing
 
@@ -304,15 +303,15 @@ api.events.listen((event) {
 });
 ```
 
-The SDK also provides a global event bus for flag evaluation events:
+The SDK also exposes a global `EventBus` type for custom event-driven workflows. Note that automatic publishing of flag evaluation events is not currently implemented by the SDK, so subscribers will only receive events that your application publishes explicitly:
 
 ```dart
 import 'package:openfeature_dart_server_sdk/event_system.dart';
 
-// Listen for flag evaluation events
+// Listen for custom flag evaluation events published by your application
 OpenFeatureEvents.instance.subscribe(
   (event) {
-    print('Flag evaluated: ${event.data['flagKey']} = ${event.data['result']}');
+    print("Flag evaluated: ${event.data['flagKey']} = ${event.data['result']}");
   },
   filter: EventFilter(
     types: {OpenFeatureEventType.flagEvaluated},
@@ -574,13 +573,13 @@ void main() {
   late OpenFeatureAPI api;
   late InMemoryProvider testProvider;
 
-  setUp(() {
+  setUp(() async {
     api = OpenFeatureAPI();
     testProvider = InMemoryProvider({
       'test-flag': true,
       'string-flag': 'test-value',
     });
-    api.setProvider(testProvider);
+    await api.setProviderAndWait(testProvider);
   });
 
   tearDown(() {


### PR DESCRIPTION
## Summary

- Fix multiple inaccurate code examples and descriptions in the README that would not compile or run as written
- Replace Go SDK terminology and patterns that were copied into the Dart README without adaptation

## Changes

1. **Dart version**: Fixed from `3.9.2` to `3.10.7` to match `pubspec.yaml` constraint (`^3.10.7`)
2. **Targeting section**: Added missing `provider: api.provider` to `FeatureClient` construction so the client is actually wired to the registered provider
3. **Hooks section**: Added missing `provider: api.provider` to `FeatureClient` construction; removed dead invocation-level hook code that was never wired in; added note that invocation-level hooks are not yet supported
4. **Logging section**: Removed non-existent `LoggingHook` class and its example (was scaffolded with `[TBD](TBD)` link and never implemented); replaced with accurate description of SDK's `package:logging` usage
5. **Domains section**: Replaced deprecated `evaluateBooleanFlag()` calls with `getClient()` + `getBooleanFlag()` pattern
6. **Eventing section**: Fixed `api.events` example to use actual `OpenFeatureEventType.PROVIDER_CONFIGURATION_CHANGED` enum value from `open_feature_event.dart`; added separate example for flag evaluation events via the global `EventBus` from `event_system.dart`
7. **Provider example**: Added missing required `metadata` getter (`ProviderMetadata`)
8. **Hook docs**: Fixed link from non-existent `./pkg/openfeature/hooks.dart` to `./lib/hooks.dart`; replaced references to non-existent `UnimplementedHook` "struct" with actual `BaseHook` class; corrected method names from PascalCase to camelCase
9. **Testing section**: Replaced Go-specific text (`NewTestProvider`, `UsingFlags(t, tt.flags)`, `Cleanup()`) with accurate Dart description using `InMemoryProvider` and `OpenFeatureAPI.resetInstance()`
10. **Transaction context**: Noted `TransactionContextManager` is a singleton