### PR TITLE
chore: resolve domain-specific providers and publish flag evaluation events 

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ final result = await client.getBooleanFlag(
 Look [here](https://openfeature.dev/ecosystem/?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Hook&instant_search%5BrefinementList%5D%5Btechnology%5D%5B0%5D=Dart) for a complete list of available hooks.
 If the hook you're looking for hasn't been created yet, see the [develop a hook](#develop-a-hook) section to learn how to build it yourself.
 
-Once you've added a hook as a dependency, it can be registered at the global, client, or flag invocation level.
+Once you've added a hook as a dependency, it can be registered at the global or client level.
 
 ```dart
 // Add a hook globally, to run on all evaluations
@@ -267,18 +267,21 @@ import 'package:openfeature_dart_server_sdk/open_feature_api.dart';
 final api = OpenFeatureAPI();
 
 // Register the default provider
-api.setProvider(InMemoryProvider({'default-flag': true}));
+await api.setProviderAndWait(InMemoryProvider({'default-flag': true}));
 
 // Register a domain-specific provider
-api.bindClientToProvider('cache-domain', 'CachedProvider');
+await api.setProviderForDomain(
+  'cache-domain',
+  InMemoryProvider({'cached-flag': true}),
+);
 
-// Client backed by default provider
+// Client backed by the default provider
 final defaultClient = api.getClient('default-client');
-await defaultClient.getBooleanFlag('my-flag', defaultValue: false);
+await defaultClient.getBooleanFlag('default-flag', defaultValue: false);
 
-// Client backed by CachedProvider
+// Client backed by the cache-domain provider
 final cacheClient = api.getClient('cache-client', domain: 'cache-domain');
-await cacheClient.getBooleanFlag('my-flag', defaultValue: false);
+await cacheClient.getBooleanFlag('cached-flag', defaultValue: false);
 ```
 
 ### Eventing
@@ -304,7 +307,7 @@ api.events.listen((event) {
 });
 ```
 
-The SDK also provides a global event bus for flag evaluation events:
+The SDK also provides a global event bus for flag evaluation events. A `flagEvaluated` event is published on every flag evaluation performed by any client:
 
 ```dart
 import 'package:openfeature_dart_server_sdk/event_system.dart';
@@ -574,13 +577,13 @@ void main() {
   late OpenFeatureAPI api;
   late InMemoryProvider testProvider;
 
-  setUp(() {
+  setUp(() async {
     api = OpenFeatureAPI();
     testProvider = InMemoryProvider({
       'test-flag': true,
       'string-flag': 'test-value',
     });
-    api.setProvider(testProvider);
+    await api.setProviderAndWait(testProvider);
   });
 
   tearDown(() {

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:logging/logging.dart';
 import 'evaluation_context.dart';
+import 'event_system.dart';
 import 'hooks.dart';
 import 'feature_provider.dart';
 import 'transaction_context.dart';
@@ -118,6 +119,24 @@ class FeatureClient {
       }
 
       _metrics.responseTimes.add(DateTime.now().difference(startTime));
+
+      // Publish flag evaluation event to the global event bus
+      OpenFeatureEvents.instance.publish(
+        OpenFeatureEvent(
+          id: '${metadata.name}:$flagKey:${DateTime.now().microsecondsSinceEpoch}',
+          type: OpenFeatureEventType.flagEvaluated,
+          data: {
+            'flagKey': flagKey,
+            'result': result.value,
+            'clientName': metadata.name,
+            'providerName': _provider.metadata.name,
+            if (result.errorCode != null) 'errorCode': result.errorCode!.name,
+            if (result.errorMessage != null)
+              'errorMessage': result.errorMessage,
+          },
+        ),
+      );
+
       return result.value;
     } catch (e) {
       _logger.warning('Error evaluating flag $flagKey: $e');

--- a/lib/open_feature_api.dart
+++ b/lib/open_feature_api.dart
@@ -139,6 +139,7 @@ class OpenFeatureAPI {
 
   late FeatureProvider _provider;
   final DomainManager _domainManager = DomainManager();
+  final Map<String, FeatureProvider> _domainProviders = {};
   final List<OpenFeatureHook> _hooks = [];
   OpenFeatureEvaluationContext? _globalContext;
 
@@ -273,11 +274,50 @@ class OpenFeatureAPI {
     _initializeDefaultProvider();
   }
 
-  /// Get or create a client
-  FeatureClient getClient(String name, {String? domain}) {
-    if (domain != null) {
-      _domainManager.getProviderForClient(domain);
+  /// Register a provider for a specific domain. Clients requested with this
+  /// domain will be backed by the given provider instead of the default one.
+  Future<void> setProviderForDomain(
+    String domain,
+    FeatureProvider provider,
+  ) async {
+    _logger.info('Setting provider for domain "$domain": ${provider.name}');
+
+    try {
+      if (provider.state == ProviderState.NOT_READY) {
+        await provider.initialize();
+      }
+
+      _domainProviders[domain] = provider;
+
+      if (provider.state == ProviderState.READY) {
+        _emitEvent(
+          OpenFeatureEventType.PROVIDER_READY,
+          'Provider ready for domain "$domain": ${provider.name}',
+        );
+      } else {
+        _emitEvent(
+          OpenFeatureEventType.PROVIDER_ERROR,
+          'Provider not ready for domain "$domain": ${provider.name}',
+          data: {'state': provider.state.name},
+        );
+      }
+    } catch (error) {
+      _logger.severe('Failed to initialize provider for domain "$domain": $error');
+      _domainProviders[domain] = provider;
+      _emitEvent(
+        OpenFeatureEventType.PROVIDER_ERROR,
+        'Provider initialization failed for domain "$domain": ${provider.name}',
+        data: error,
+      );
     }
+  }
+
+  /// Get or create a client. If [domain] is provided and a provider was
+  /// registered for that domain via [setProviderForDomain], the client is
+  /// backed by that provider; otherwise it falls back to the default provider.
+  FeatureClient getClient(String name, {String? domain}) {
+    final resolvedProvider =
+        (domain != null ? _domainProviders[domain] : null) ?? _provider;
 
     // Build hook manager with global hooks
     final hookManager = HookManager();
@@ -292,7 +332,7 @@ class OpenFeatureAPI {
       defaultContext: _globalContext != null
           ? EvaluationContext(attributes: _globalContext!.attributes)
           : EvaluationContext(attributes: {}),
-      provider: _provider,
+      provider: resolvedProvider,
     );
   }
 

--- a/lib/open_feature_api.dart
+++ b/lib/open_feature_api.dart
@@ -307,7 +307,7 @@ class OpenFeatureAPI {
       _emitEvent(
         OpenFeatureEventType.PROVIDER_ERROR,
         'Provider initialization failed for domain "$domain": ${provider.name}',
-        data: error,
+        data: {'error': error.toString()},
       );
     }
   }
@@ -390,6 +390,17 @@ class OpenFeatureAPI {
   }
 
   Future<void> dispose() async {
+    for (final entry in _domainProviders.entries) {
+      try {
+        await entry.value.shutdown();
+      } catch (e) {
+        _logger.warning(
+          'Error shutting down provider for domain "${entry.key}": $e',
+        );
+      }
+    }
+    _domainProviders.clear();
+
     await _providerStreamController.close();
     await _eventStreamController.close();
     await _domainUpdatesController.close();


### PR DESCRIPTION
## This PR

  ## Summary                                                                                                                                                 
                                                                                                                                                             
  Follow-up to #94 / #95. Addresses the remaining Copilot/Gemini review comments                                                                             
  from Jonathan's original PR by fixing the underlying SDK behavior (rather than
  caveating the README), plus two pure documentation fixes.                                                                                                  
                                                                                                                                                             
  ## Changes                                                                                                                                                 
                                                                                                                                                             
  ### `lib/open_feature_api.dart`                                                                                                                            
  - Added `setProviderForDomain(String domain, FeatureProvider provider)` to                                                                                 
    register a provider per domain. Initializes the provider if needed and emits                                                                             
    `PROVIDER_READY` / `PROVIDER_ERROR` events consistent with `setProvider`.
  - `getClient(name, {domain})` now actually resolves the domain-specific
    provider from the new registry and falls back to the default provider when                                                                               
    no domain match exists. Previously the `domain` argument was accepted but                                                                                
    silently discarded.                                                                                                                                      
                                                                                                                                                             
  ### `lib/client.dart`                                                                                                                                      
  - `FeatureClient._evaluateFlag` now publishes an                                                                                                           
    `OpenFeatureEventType.flagEvaluated` event to `OpenFeatureEvents.instance`                                                                               
    on every evaluation, carrying `flagKey`, `result`, `clientName`,                                                                                         
    `providerName`, and (when present) `errorCode` / `errorMessage`.
    Previously the enum value existed but nothing ever published it.                                                                                         
                                                                                                                                                             
  ### `README.md`                                                                                                                                            
  - **Hooks** — "global, client, or flag invocation level" corrected to                                                                                      
    "global or client level" to match the note that invocation-level hooks are                                                                               
    not yet supported.                                                                                                                                       
  - **Domains** — example rewritten to use `setProviderAndWait` +                                                                                            
    `setProviderForDomain`; both the default-client and cache-domain client                                                                                  
    examples now run as written.                                                                                                                             
  - **Eventing** — flag-evaluation event bus example is now accurate; previous                                                                               
    caveat about missing auto-publish removed.                                                                                                               
  - **Testing** — `setUp` switched to `async` with `await api.setProviderAndWait(...)`                                                                       
    to avoid races on provider readiness.   


