### PR TITLE
chore: Multi-Provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,10 @@
 
 <!-- x-hide-in-docs-end -->
 <p align="center" class="github-badges">
-  <!-- Specification Badge -->
   <a href="https://github.com/open-feature/spec/releases/tag/v0.8.0">
     <img alt="Specification" src="https://img.shields.io/static/v1?label=specification&message=v0.8.0&color=yellow&style=for-the-badge" />
   </a>
   <!-- x-release-please-start-version -->
-
   <a href="https://github.com/open-feature/dart-server-sdk/releases/tag/v0.0.17">
     <img alt="Release" src="https://img.shields.io/static/v1?label=release&message=v0.0.17&color=blue&style=for-the-badge" />
   </a>
@@ -26,7 +24,7 @@
   </a>
 
   <br/>
-  <!-- Dart-Specific Badges -->
+
   <a href="https://pub.dev/packages/openfeature_dart_server_sdk">
     <img alt="Pub Version" src="https://img.shields.io/pub/v/openfeature_dart_server_sdk.svg?style=for-the-badge" />
   </a>
@@ -42,20 +40,24 @@
 </p>
 <!-- x-hide-in-docs-start -->
 
-:warning: This repository is a work in progress repository for an implementation of the `dart-server-sdk`.
+Warning: this repository is still an in-progress implementation of the
+`dart-server-sdk`.
 
-[OpenFeature](https://openfeature.dev) is an open specification that provides a vendor-agnostic, community-driven API for feature flagging that works with your favorite feature flag management tool.
+[OpenFeature](https://openfeature.dev) is an open specification that provides a
+vendor-agnostic, community-driven API for feature flagging that works with your
+favorite feature flag management tool.
 
 <!-- x-hide-in-docs-end -->
 
-## 🚀 Quick start
+## Quick start
 
 ### Requirements
 
 Dart language version: [3.11.4](https://dart.dev/get-dart/archive)
 
 > [!NOTE]
-> The OpenFeature DartServer SDK only supports the latest currently maintained Dart language versions.
+> The OpenFeature Dart Server SDK only supports the latest currently maintained
+> Dart language versions.
 
 ### Install
 
@@ -68,87 +70,81 @@ dependencies:
 
 <!-- x-release-please-end -->
 
-### Then run:
+### Then run
 
-```
+```text
 dart pub get
 ```
 
 ### Usage
 
 ```dart
-import 'dart:async';
-import 'package:openfeature_dart_server_sdk/open_feature_api.dart';
 import 'package:openfeature_dart_server_sdk/feature_provider.dart';
+import 'package:openfeature_dart_server_sdk/open_feature_api.dart';
 
 void main() async {
-  // Get the API instance
   final api = OpenFeatureAPI();
 
-  // Register your feature flag provider and wait for it to be ready
-  await api.setProviderAndWait(InMemoryProvider({
-    'new-feature': true,
-    'welcome-message': 'Hello, OpenFeature!'
-  }));
+  await api.setProviderAndWait(
+    InMemoryProvider({
+      'new-feature': true,
+      'welcome-message': 'Hello, OpenFeature!',
+    }),
+  );
 
-  // Create a client
   final client = api.getClient('my-app');
-
-  // Evaluate your feature flags
   final newFeatureEnabled = await client.getBooleanFlag(
     'new-feature',
     defaultValue: false,
   );
 
-  // Get full evaluation details if needed
   final details = await client.getBooleanDetails(
     'new-feature',
     defaultValue: false,
   );
   print('Reason: ${details.reason}, Variant: ${details.variant}');
 
-  // Use the returned flag value
   if (newFeatureEnabled) {
-    print('New feature is enabled!');
-
     final welcomeMessage = await client.getStringFlag(
       'welcome-message',
       defaultValue: 'Welcome!',
     );
-
     print(welcomeMessage);
   }
 }
 ```
 
-### API Reference
+### API reference
 
-See [here](https://pub.dev/documentation/openfeature_dart_server_sdk/latest/) for the complete API documentation.
+See
+[pub.dev/documentation/openfeature_dart_server_sdk/latest](https://pub.dev/documentation/openfeature_dart_server_sdk/latest/)
+for the complete API documentation.
 
-## 🌟 Features
+## Features
 
-| Status | Features                                                            | Description                                                                                                                                                  |
-| ------ | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| ✅     | [Providers](#providers)                                             | Integrate with a commercial, open source, or in-house feature management tool.                                                                               |
-| ✅     | [Targeting](#targeting)                                             | Contextually-aware flag evaluation using [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context).                           |
-| ✅     | [Hooks](#hooks)                                                     | Add functionality to various stages of the flag evaluation life-cycle.                                                                                       |
-| ✅     | [Tracking](#tracking)                                               | Associate user actions with feature flag evaluations for experimentation.                                                                                    |
-| ✅     | [Logging](#logging)                                                 | Integrate with popular logging packages.                                                                                                                     |
-| ✅     | [Domains](#domains)                                                 | Logically bind clients with providers.                                                                                                                       |
-| ✅     | [Eventing](#eventing)                                               | React to state changes in the provider or flag management system.                                                                                            |
-| ✅     | [Shutdown](#shutdown)                                               | Gracefully clean up a provider during application shutdown.                                                                                                  |
-| ✅     | [Transaction Context Propagation](#transaction-context-propagation) | Set a specific [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context) for a transaction (e.g. an HTTP request or a thread) |
-| ✅     | [Extending](#extending)                                             | Extend OpenFeature with custom providers and hooks.                                                                                                          |
+| Status | Feature | Description |
+| ------ | ------- | ----------- |
+| Implemented | [Providers](#providers) | Integrate with a commercial, open source, or in-house feature management tool. |
+| Implemented | [Targeting](#targeting) | Contextually-aware flag evaluation using [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context). |
+| Implemented | [Hooks](#hooks) | Add functionality to various stages of the flag evaluation life-cycle. |
+| Implemented | [Tracking](#tracking) | Associate user actions with feature flag evaluations for experimentation. |
+| Implemented | [Logging](#logging) | Integrate with popular logging packages. |
+| Implemented | [Domains](#domains) | Logically bind clients with providers. |
+| Experimental | [Multi-Provider](#multi-provider-experimental) | Compose multiple providers behind one SDK-level provider with a selection strategy. |
+| Implemented | [Eventing](#eventing) | React to state changes in the provider or flag management system. |
+| Implemented | [Shutdown](#shutdown) | Gracefully clean up a provider during application shutdown. |
+| Implemented | [Transaction Context Propagation](#transaction-context-propagation) | Set a specific [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context) for a transaction such as an HTTP request or thread. |
+| Implemented | [Extending](#extending) | Extend OpenFeature with custom providers and hooks. |
 
-<sub>Implemented: ✅ | In-progress: ⚠️ | Not implemented yet: ❌</sub>
+<sub>Status values used here: Implemented | Experimental | Not implemented</sub>
 
 ### Providers
 
-[Providers](https://openfeature.dev/docs/reference/concepts/provider) are an abstraction between a flag management system and the OpenFeature SDK.
-Look [here](https://openfeature.dev//ecosystem?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Provider&instant_search%5BrefinementList%5D%5BallTechnologies%5D%5B0%5D=Dart) for a complete list of available providers.
-If the provider you're looking for hasn't been created yet, see the [develop a provider](#develop-a-provider) section to learn how to build it yourself.
-
-Once you've added a provider as a dependency, it can be registered with OpenFeature like this:
+[Providers](https://openfeature.dev/docs/reference/concepts/provider) are an
+abstraction between a flag management system and the OpenFeature SDK. Look
+[here](https://openfeature.dev//ecosystem?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Provider&instant_search%5BrefinementList%5D%5BallTechnologies%5D%5B0%5D=Dart)
+for a complete list of available providers. If the provider you need does not
+exist yet, see [Develop a provider](#develop-a-provider).
 
 ```dart
 final api = OpenFeatureAPI();
@@ -157,149 +153,188 @@ api.setProvider(MyProvider());
 
 ### Targeting
 
-Sometimes, the value of a flag must consider some dynamic criteria about the application or user, such as the user's location, IP, email address, or the server's location.
-In OpenFeature, we refer to this as [targeting](https://openfeature.dev/specification/glossary#targeting).
-If the flag management system you're using supports targeting, you can provide the input data using the [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context).
+Sometimes the value of a flag must consider dynamic criteria about the
+application or user, such as location, IP, or organization. In OpenFeature this
+is called
+[targeting](https://openfeature.dev/specification/glossary#targeting). If your
+flag management system supports targeting, you can provide the input data using
+the
+[evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context).
 
 ```dart
-// Set a value to the global context
 final api = OpenFeatureAPI();
-api.setGlobalContext(OpenFeatureEvaluationContext({
-  'region': 'us-east-1-iah-1a',
-}));
+api.setGlobalContext(
+  OpenFeatureEvaluationContext({
+    'region': 'us-east-1-iah-1a',
+  }),
+);
 
-// Create a client with a client-level default context
 final client = FeatureClient(
   metadata: ClientMetadata(name: 'my-app'),
   hookManager: HookManager(),
-  defaultContext: EvaluationContext(attributes: {
-    'version': '1.4.6',
-  }),
+  defaultContext: const EvaluationContext(
+    attributes: {
+      'version': '1.4.6',
+    },
+  ),
   provider: api.provider,
 );
 
-// Set a value to the invocation context
 final result = await client.getBooleanFlag(
   'feature-flag',
   defaultValue: false,
-  context: EvaluationContext(attributes: {
-    'user': 'user-123',
-    'company': 'Initech',
-  }),
+  context: const EvaluationContext(
+    attributes: {
+      'user': 'user-123',
+      'company': 'Initech',
+    },
+  ),
 );
 ```
 
 ### Hooks
 
-[Hooks](https://openfeature.dev/docs/reference/concepts/hooks) allow for custom logic to be added at well-defined points of the flag evaluation life-cycle
-Look [here](https://openfeature.dev/ecosystem/?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Hook&instant_search%5BrefinementList%5D%5Btechnology%5D%5B0%5D=Dart) for a complete list of available hooks.
-If the hook you're looking for hasn't been created yet, see the [develop a hook](#develop-a-hook) section to learn how to build it yourself.
+[Hooks](https://openfeature.dev/docs/reference/concepts/hooks) allow custom
+logic to be added at well-defined points of the flag evaluation life-cycle. Look
+[here](https://openfeature.dev/ecosystem/?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Hook&instant_search%5BrefinementList%5D%5Btechnology%5D%5B0%5D=Dart)
+for a complete list of available hooks.
 
-Once you've added a hook as a dependency, it can be registered at the global or client level.
+Once you have added a hook dependency, it can be registered at the global or
+client level.
 
 ```dart
-// Add a hook globally, to run on all evaluations
 final api = OpenFeatureAPI();
 api.addHooks([MyGlobalHook()]);
 
-// Add a hook on this client, to run on all evaluations made by this client
-final hookManager = HookManager();
-hookManager.addHook(MyClientHook());
-
-final client = FeatureClient(
-  metadata: ClientMetadata(name: 'my-app'),
-  hookManager: hookManager,
-  defaultContext: EvaluationContext(attributes: {}),
-  provider: api.provider,
-);
+final client = api.getClient('my-app');
+client.addHook(MyClientHook());
 ```
 
 > [!NOTE]
-> Invocation-level hooks are not yet supported. Hooks can currently be registered at the global or client level.
+> Invocation-level hooks are not yet supported. Hooks can currently be
+> registered at the global or client level.
+
+Before hooks may return context updates. Any returned attributes are merged into
+the evaluation context before the provider is called.
 
 ### Tracking
 
-The [tracking API](https://openfeature.dev/specification/sections/tracking/) allows you to use OpenFeature abstractions and objects to associate user actions with feature flag evaluations.
-This is essential for robust experimentation powered by feature flags.
-For example, a flag enhancing the appearance of a UI component might drive user engagement to a new feature; to test this hypothesis, telemetry collected by a [hook](#hooks) or [provider](#providers) can be associated with telemetry reported in the client's `track` function.
-
-Note that some providers may not support tracking; check the documentation for your provider for more information.
+The
+[tracking API](https://openfeature.dev/specification/sections/tracking/)
+allows you to associate user actions with feature flag evaluations. This is
+useful for experimentation and downstream analytics.
 
 ```dart
-import 'package:openfeature_dart_server_sdk/open_feature_api.dart';
+import 'package:openfeature_dart_server_sdk/evaluation_context.dart';
 import 'package:openfeature_dart_server_sdk/feature_provider.dart';
+import 'package:openfeature_dart_server_sdk/open_feature_api.dart';
 
 final api = OpenFeatureAPI();
 final client = api.getClient('my-app');
 
-// Track a user action associated with a feature flag evaluation
 await client.track(
   'checkout-completed',
-  context: EvaluationContext(attributes: {
-    'user': 'user-123',
-  }),
-  trackingDetails: TrackingEventDetails(
+  context: const EvaluationContext(
+    attributes: {
+      'user': 'user-123',
+    },
+  ),
+  trackingDetails: const TrackingEventDetails(
     value: 99.99,
     attributes: {'currency': 'USD'},
   ),
 );
 ```
 
+Note that some providers may not support tracking. Check the provider
+documentation for details.
+
 ### Logging
 
-Note that in accordance with the OpenFeature specification, the SDK doesn't generally log messages during flag evaluation.
+In accordance with the OpenFeature specification, the SDK does not generally log
+messages during flag evaluation.
 
-The SDK uses the [package:logging](https://pub.dev/packages/logging) structured logging API internally.
-You can configure log levels and listeners to capture SDK log output for troubleshooting and debugging.
+The SDK uses the [package:logging](https://pub.dev/packages/logging) structured
+logging API internally. You can configure log levels and listeners to capture
+SDK output for troubleshooting and debugging.
 
-See [hooks](#hooks) for more information on adding custom logging behavior via hooks.
+For lifecycle-level logging, use the built-in `LoggingHook` or
+`OpenTelemetryHook`. `LoggingHook` redacts evaluation-context values by default
+and only emits context keys unless `includeContext: true` is set explicitly.
 
 ### Domains
 
-Clients can be assigned to a domain. A domain is a logical identifier that can be used to associate clients with a particular provider. If a domain has no associated provider, the default provider is used.
+Clients can be assigned to a domain. A domain is a logical identifier that can
+be used to associate clients with a particular provider. If a domain has no
+associated provider, the default provider is used.
 
 ```dart
-import 'package:openfeature_dart_server_sdk/domain_manager.dart';
 import 'package:openfeature_dart_server_sdk/feature_provider.dart';
 import 'package:openfeature_dart_server_sdk/open_feature_api.dart';
 
-// Get the OpenFeature API instance
 final api = OpenFeatureAPI();
 
-// Register the default provider
-await api.setProviderAndWait(InMemoryProvider({'default-flag': true}));
+api.setProvider(InMemoryProvider({'default-flag': true}));
 
-// Register a domain-specific provider
-await api.setProviderForDomain(
-  'cache-domain',
-  InMemoryProvider({'cached-flag': true}),
-);
+api.registerProvider(CustomCacheProvider());
+api.bindClientToProvider('cache-domain', 'CustomCacheProvider');
 
-// Client backed by the default provider
 final defaultClient = api.getClient('default-client');
 await defaultClient.getBooleanFlag('default-flag', defaultValue: false);
 
-// Client backed by the cache-domain provider
 final cacheClient = api.getClient('cache-client', domain: 'cache-domain');
 await cacheClient.getBooleanFlag('cached-flag', defaultValue: false);
 ```
 
+### Multi-Provider (experimental)
+
+OpenFeature treats Multi-Provider as an SDK-level utility rather than behavior
+owned by any one provider. It is useful for migrations and fallback
+compositions where one client should consult more than one underlying provider.
+
+This SDK includes an experimental `MultiProvider` implementation with a default
+`FirstMatchStrategy`. Providers are evaluated in order. A `FLAG_NOT_FOUND`
+result is treated as a miss and evaluation continues with the next provider.
+Initialization and connection fan out across all configured providers, and
+tracking is treated as best-effort fan-out.
+
+```dart
+import 'package:openfeature_dart_server_sdk/feature_provider.dart';
+import 'package:openfeature_dart_server_sdk/multi_provider.dart';
+import 'package:openfeature_dart_server_sdk/open_feature_api.dart';
+
+final api = OpenFeatureAPI();
+final multiProvider = MultiProvider([
+  InMemoryProvider({'new-feature': true}),
+  InMemoryProvider({'fallback-feature': true}),
+]);
+
+await api.setProviderAndWait(multiProvider);
+
+final client = api.getClient('my-app');
+final enabled = await client.getBooleanFlag(
+  'new-feature',
+  defaultValue: false,
+);
+```
+
+Treat the current Multi-Provider surface as experimental until the strategy API
+and documentation settle further.
+
 ### Eventing
 
-Events allow you to react to state changes in the provider or underlying flag management system, such as flag definition changes, provider readiness, or error conditions.
-Initialization events (`PROVIDER_READY` on success, `PROVIDER_ERROR` on failure) are dispatched for every provider.
-Some providers support additional events, such as `PROVIDER_CONFIGURATION_CHANGED`.
-
-Please refer to the documentation of the provider you're using to see what events are supported.
+Events allow you to react to state changes in the provider or underlying flag
+management system, such as flag definition changes, provider readiness, or error
+conditions. Initialization events (`PROVIDER_READY` on success,
+`PROVIDER_ERROR` on failure) are dispatched for every provider. Some providers
+support additional events such as `PROVIDER_CONFIGURATION_CHANGED`.
 
 ```dart
 import 'package:openfeature_dart_server_sdk/open_feature_api.dart';
 import 'package:openfeature_dart_server_sdk/open_feature_event.dart';
 
-// Get the OpenFeature API instance
 final api = OpenFeatureAPI();
 
-// Listen for provider configuration change events
 api.events.listen((event) {
   if (event.type == OpenFeatureEventType.PROVIDER_CONFIGURATION_CHANGED) {
     print('Provider configuration changed: ${event.message}');
@@ -307,12 +342,22 @@ api.events.listen((event) {
 });
 ```
 
-The SDK also provides a global event bus for flag evaluation events. A `flagEvaluated` event is published on every flag evaluation performed by any client:
+Client-scoped handlers are also available. A client only receives events for
+its associated provider.
+
+```dart
+final client = api.getClient('my-app');
+final sub = client.addHandler((event) {
+  print('Client received event: ${event.type}');
+});
+await client.removeHandler(sub);
+```
+
+The SDK also exposes a global event bus for SDK-specific flag evaluation events.
 
 ```dart
 import 'package:openfeature_dart_server_sdk/event_system.dart';
 
-// Listen for flag evaluation events
 OpenFeatureEvents.instance.subscribe(
   (event) {
     print('Flag evaluated: ${event.data['flagKey']} = ${event.data['result']}');
@@ -325,43 +370,41 @@ OpenFeatureEvents.instance.subscribe(
 
 ### Shutdown
 
-The OpenFeature API provides mechanisms to perform a cleanup of all registered providers.
-This should only be called when your application is in the process of shutting down.
+The OpenFeature API provides mechanisms to perform cleanup of registered
+providers. This should only be called when your application is shutting down.
 
 ```dart
 import 'package:openfeature_dart_server_sdk/open_feature_api.dart';
 import 'package:openfeature_dart_server_sdk/shutdown_manager.dart';
 
-// Get the OpenFeature API instance
 final api = OpenFeatureAPI();
 
-// Register shutdown hooks
 final shutdownManager = ShutdownManager();
-shutdownManager.registerHook(ShutdownHook(
-  name: 'provider-cleanup',
-  phase: ShutdownPhase.PROVIDER_SHUTDOWN,
-  execute: () async {
-    // Clean up provider resources
-    await api.dispose();
-  },
-));
+shutdownManager.registerHook(
+  ShutdownHook(
+    name: 'provider-cleanup',
+    phase: ShutdownPhase.PROVIDER_SHUTDOWN,
+    execute: () async {
+      await api.dispose();
+    },
+  ),
+);
 
-// During application shutdown
 await shutdownManager.shutdown();
 ```
 
 ### Transaction Context Propagation
 
-Transaction context is a container for transaction-specific evaluation context (e.g. user id, user agent, IP).
-Transaction context can be set where specific data is available (e.g. an auth service or request handler), and by using the transaction context propagator, it will automatically be applied to all flag evaluations within a transaction (e.g. a request or thread).
+Transaction context is a container for transaction-specific evaluation context,
+such as user id, user agent, or IP. Transaction context can be set where
+request-specific data is available and then automatically applied to flag
+evaluations inside that transaction.
 
 ```dart
 import 'package:openfeature_dart_server_sdk/transaction_context.dart';
 
-// Get the transaction context manager (singleton)
 final transactionManager = TransactionContextManager();
 
-// Set the transaction context
 final context = TransactionContext(
   transactionId: 'request-123',
   attributes: {
@@ -371,10 +414,8 @@ final context = TransactionContext(
 );
 transactionManager.pushContext(context);
 
-// The transaction context will automatically be applied to flag evaluations
 await client.getBooleanFlag('my-flag', defaultValue: false);
 
-// Execute code with a specific transaction context
 await transactionManager.withContext(
   'transaction-id',
   {'user': 'user-123'},
@@ -383,7 +424,6 @@ await transactionManager.withContext(
   },
 );
 
-// When the transaction is complete, pop the context
 transactionManager.popContext();
 ```
 
@@ -391,12 +431,11 @@ transactionManager.popContext();
 
 ### Develop a provider
 
-To develop a provider, you need to create a new project and include the OpenFeature SDK as a dependency.
-This can be a new repository or included in [the existing contrib repository](https://github.com/open-feature/dart-server-sdk-contrib) available under the OpenFeature organization.
-You'll then need to write the provider by implementing the `FeatureProvider` interface exported by the OpenFeature SDK.
+To develop a provider, create a new project and include the OpenFeature SDK as
+a dependency. This can live in a new repository or in the existing
+[contrib repository](https://github.com/open-feature/dart-server-sdk-contrib).
 
 ```dart
-import 'dart:async';
 import 'package:openfeature_dart_server_sdk/feature_provider.dart';
 
 class MyCustomProvider implements FeatureProvider {
@@ -413,28 +452,20 @@ class MyCustomProvider implements FeatureProvider {
   ProviderConfig get config => ProviderConfig();
 
   @override
-  Future<void> initialize([Map<String, dynamic>? config]) async {
-    // Initialize your provider
-  }
+  Future<void> initialize([Map<String, dynamic>? config]) async {}
 
   @override
-  Future<void> connect() async {
-    // Connection logic if needed
-  }
+  Future<void> connect() async {}
 
   @override
-  Future<void> shutdown() async {
-    // Clean up resources
-  }
+  Future<void> shutdown() async {}
 
   @override
   Future<void> track(
     String trackingEventName, {
     Map<String, dynamic>? evaluationContext,
     TrackingEventDetails? trackingDetails,
-  }) async {
-    // Send tracking event to your backend, or no-op if unsupported
-  }
+  }) async {}
 
   @override
   Future<FlagEvaluationResult<bool>> getBooleanFlag(
@@ -442,10 +473,9 @@ class MyCustomProvider implements FeatureProvider {
     bool defaultValue, {
     Map<String, dynamic>? context,
   }) async {
-    // Evaluate boolean flag
     return FlagEvaluationResult(
       flagKey: flagKey,
-      value: true, // Your implementation here
+      value: true,
       evaluatedAt: DateTime.now(),
       evaluatorId: name,
     );
@@ -457,10 +487,9 @@ class MyCustomProvider implements FeatureProvider {
     String defaultValue, {
     Map<String, dynamic>? context,
   }) async {
-    // Evaluate string flag
     return FlagEvaluationResult(
       flagKey: flagKey,
-      value: 'value', // Your implementation here
+      value: 'value',
       evaluatedAt: DateTime.now(),
       evaluatorId: name,
     );
@@ -472,10 +501,9 @@ class MyCustomProvider implements FeatureProvider {
     int defaultValue, {
     Map<String, dynamic>? context,
   }) async {
-    // Evaluate integer flag
     return FlagEvaluationResult(
       flagKey: flagKey,
-      value: 42, // Your implementation here
+      value: 42,
       evaluatedAt: DateTime.now(),
       evaluatorId: name,
     );
@@ -487,10 +515,9 @@ class MyCustomProvider implements FeatureProvider {
     double defaultValue, {
     Map<String, dynamic>? context,
   }) async {
-    // Evaluate double flag
     return FlagEvaluationResult(
       flagKey: flagKey,
-      value: 3.14, // Your implementation here
+      value: 3.14,
       evaluatedAt: DateTime.now(),
       evaluatorId: name,
     );
@@ -502,10 +529,9 @@ class MyCustomProvider implements FeatureProvider {
     Map<String, dynamic> defaultValue, {
     Map<String, dynamic>? context,
   }) async {
-    // Evaluate object flag
     return FlagEvaluationResult(
       flagKey: flagKey,
-      value: {'key': 'value'}, // Your implementation here
+      value: {'key': 'value'},
       evaluatedAt: DateTime.now(),
       evaluatorId: name,
     );
@@ -513,18 +539,18 @@ class MyCustomProvider implements FeatureProvider {
 }
 ```
 
-> Built a new provider? [Let us know](https://github.com/open-feature/openfeature.dev/issues/new?assignees=&labels=provider&projects=&template=document-provider.yaml&title=%5BProvider%5D%3A+) so we can add it to the docs!
+> Built a new provider?
+> [Let us know](https://github.com/open-feature/openfeature.dev/issues/new?assignees=&labels=provider&projects=&template=document-provider.yaml&title=%5BProvider%5D%3A+)
+> so we can add it to the docs.
 
 ### Develop a hook
 
-To develop a hook, you need to create a new project and include the OpenFeature SDK as a dependency.
-This can be a new repository or included in [the existing contrib repository](https://github.com/open-feature/dart-server-sdk-contrib) available under the OpenFeature organization.
-Implement your own hook by conforming to the [Hook interface](./lib/hooks.dart).
-To satisfy the interface, all methods (`before`/`after`/`finally_`/`error`) need to be defined.
-To avoid defining empty functions, extend the `BaseHook` class (which provides no-op default implementations for all methods).
+To develop a hook, create a new project and include the OpenFeature SDK as a
+dependency. This can live in a new repository or in the existing
+[contrib repository](https://github.com/open-feature/dart-server-sdk-contrib).
+Implement your own hook by using the hook interfaces exported by the SDK.
 
 ```dart
-import 'dart:async';
 import 'package:openfeature_dart_server_sdk/hooks.dart';
 
 class MyCustomHook extends BaseHook {
@@ -532,20 +558,20 @@ class MyCustomHook extends BaseHook {
     : super(metadata: HookMetadata(name: 'MyCustomHook'));
 
   @override
-  Future<void> before(HookContext context) async {
-    // Code to run before flag evaluation
+  Future<Map<String, dynamic>?> before(HookContext context) async {
     print('Before evaluating flag: ${context.flagKey}');
+    return {
+      'requestSource': 'my-hook',
+    };
   }
 
   @override
   Future<void> after(HookContext context) async {
-    // Code to run after successful flag evaluation
     print('After evaluating flag: ${context.flagKey}, result: ${context.result}');
   }
 
   @override
   Future<void> error(HookContext context) async {
-    // Code to run when an error occurs during flag evaluation
     print('Error evaluating flag: ${context.flagKey}, error: ${context.error}');
   }
 
@@ -555,23 +581,24 @@ class MyCustomHook extends BaseHook {
     EvaluationDetails? evaluationDetails, [
     HookHints? hints,
   ]) async {
-    // Code to run regardless of success or failure
     print('Finished evaluating flag: ${context.flagKey}');
   }
 }
 ```
 
-> Built a new hook? [Let us know](https://github.com/open-feature/openfeature.dev/issues/new?assignees=&labels=hook&projects=&template=document-hook.yaml&title=%5BHook%5D%3A+) so we can add it to the docs!
+> Built a new hook?
+> [Let us know](https://github.com/open-feature/openfeature.dev/issues/new?assignees=&labels=hook&projects=&template=document-hook.yaml&title=%5BHook%5D%3A+)
+> so we can add it to the docs.
 
 ## Testing
 
-Use the `InMemoryProvider` to set flags for the scope of a test.
-Use `OpenFeatureAPI.resetInstance()` in `tearDown` to clean up between tests.
+Use the `InMemoryProvider` to set flags for the scope of a test. Use
+`OpenFeatureAPI.resetInstance()` in `tearDown` to clean up between tests.
 
 ```dart
-import 'package:test/test.dart';
-import 'package:openfeature_dart_server_sdk/open_feature_api.dart';
 import 'package:openfeature_dart_server_sdk/feature_provider.dart';
+import 'package:openfeature_dart_server_sdk/open_feature_api.dart';
+import 'package:test/test.dart';
 
 void main() {
   late OpenFeatureAPI api;
@@ -592,13 +619,19 @@ void main() {
 
   test('evaluates boolean flag correctly', () async {
     final client = api.getClient('test-client');
-    final result = await client.getBooleanFlag('test-flag', defaultValue: false);
+    final result = await client.getBooleanFlag(
+      'test-flag',
+      defaultValue: false,
+    );
     expect(result, isTrue);
   });
 
   test('evaluates string flag correctly', () async {
     final client = api.getClient('test-client');
-    final result = await client.getStringFlag('string-flag', defaultValue: 'default');
+    final result = await client.getStringFlag(
+      'string-flag',
+      defaultValue: 'default',
+    );
     expect(result, equals('test-value'));
   });
 }
@@ -606,18 +639,20 @@ void main() {
 
 <!-- x-hide-in-docs-start -->
 
-## ⭐️ Support the project
+## Support the project
 
-- Give this repo a ⭐️!
+- Give this repo a star.
 - Follow us on social media:
   - Twitter: [@openfeature](https://twitter.com/openfeature)
   - LinkedIn: [OpenFeature](https://www.linkedin.com/company/openfeature/)
 - Join us on [Slack](https://cloud-native.slack.com/archives/C0344AANLA1)
-- For more, check out our [community page](https://openfeature.dev/community/)
+- For more, check out our
+  [community page](https://openfeature.dev/community/)
 
-## 🤝 Contributing
+## Contributing
 
-Interested in contributing? Great, we'd love your help! To get started, take a look at the [CONTRIBUTING](CONTRIBUTING.md) guide.
+Interested in contributing? Take a look at the
+[CONTRIBUTING](CONTRIBUTING.md) guide.
 
 ### Thanks to everyone that has already contributed
 

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 import 'package:logging/logging.dart';
 import 'evaluation_context.dart';
-import 'event_system.dart';
-import 'hooks.dart';
 import 'feature_provider.dart';
+import 'hooks.dart';
+import 'open_feature_event.dart';
 import 'transaction_context.dart';
 
 /// Client metadata for identification
@@ -49,24 +49,242 @@ class FeatureClient {
   final ClientMetadata metadata;
   final HookManager _hookManager;
   final EvaluationContext _defaultContext;
+  final EvaluationContext _apiContext;
   final FeatureProvider _provider;
   final TransactionContextManager _transactionManager;
   final ClientMetrics _metrics = ClientMetrics();
+  final StreamController<OpenFeatureEvent> _eventController =
+      StreamController<OpenFeatureEvent>.broadcast();
+  StreamSubscription<OpenFeatureEvent>? _eventSubscription;
 
   FeatureClient({
     required this.metadata,
     required HookManager hookManager,
     required EvaluationContext defaultContext,
+    EvaluationContext? apiContext,
     FeatureProvider? provider,
     TransactionContextManager? transactionManager,
+    Stream<OpenFeatureEvent>? eventStream,
   }) : _hookManager = hookManager,
        _defaultContext = defaultContext,
+       _apiContext = apiContext ?? const EvaluationContext(attributes: {}),
        _provider = provider ?? InMemoryProvider({}),
        _transactionManager = transactionManager ?? TransactionContextManager() {
-    // Ensure provider is initialized
     if (_provider.state == ProviderState.NOT_READY) {
       _provider.initialize();
     }
+
+    if (eventStream != null) {
+      _eventSubscription = eventStream.listen(_forwardEvent);
+    }
+  }
+
+  void _forwardEvent(OpenFeatureEvent event) {
+    final eventProvider = event.providerMetadata?.name;
+    if (eventProvider == null || eventProvider == _provider.metadata.name) {
+      _eventController.add(event);
+    }
+  }
+
+  Stream<OpenFeatureEvent> get events => _eventController.stream;
+
+  StreamSubscription<OpenFeatureEvent> addHandler(
+    void Function(OpenFeatureEvent event) handler,
+  ) => events.listen(handler);
+
+  Future<void> removeHandler(StreamSubscription<OpenFeatureEvent> handler) =>
+      handler.cancel();
+
+  void addHook(Hook hook) {
+    _hookManager.addHook(hook);
+  }
+
+  void addHooks(Iterable<Hook> hooks) {
+    for (final hook in hooks) {
+      _hookManager.addHook(hook);
+    }
+  }
+
+  void removeHook(Hook hook) {
+    _hookManager.removeHook(hook);
+  }
+
+  Map<String, dynamic> _buildEffectiveContext(Map<String, dynamic>? context) {
+    return {
+      ..._apiContext.attributes,
+      ..._transactionManager.currentContext?.effectiveAttributes ?? {},
+      ..._defaultContext.attributes,
+      ...context ?? {},
+    };
+  }
+
+  FlagValueType _inferFlagValueType<T>(T defaultValue) {
+    if (defaultValue is bool) return FlagValueType.BOOLEAN;
+    if (defaultValue is String) return FlagValueType.STRING;
+    if (defaultValue is int) return FlagValueType.INTEGER;
+    if (defaultValue is double) return FlagValueType.DOUBLE;
+    return FlagValueType.OBJECT;
+  }
+
+  EvaluationDetails _createEvaluationDetails<T>(FlagEvaluationResult<T> result) {
+    return EvaluationDetails(
+      flagKey: result.flagKey,
+      value: result.value,
+      variant: result.variant,
+      reason: result.reason,
+      evaluationTime: result.evaluatedAt,
+      additionalDetails: result.details,
+    );
+  }
+
+  Exception _asException(Object error) {
+    return error is Exception ? error : Exception(error.toString());
+  }
+
+  Exception _providerErrorAsException<T>(FlagEvaluationResult<T> result) {
+    return ProviderException(
+      result.errorMessage ?? 'Provider returned an evaluation error.',
+      code: result.errorCode ?? ErrorCode.GENERAL,
+      details: result.details,
+    );
+  }
+
+  FlagEvaluationResult<T> _exceptionResult<T>(
+    String flagKey,
+    T defaultValue,
+    Exception error,
+  ) {
+    final errorCode = error is ProviderException
+        ? error.code
+        : ErrorCode.GENERAL;
+    final errorMessage = error is ProviderException
+        ? error.message
+        : error.toString();
+
+    return FlagEvaluationResult<T>(
+      flagKey: flagKey,
+      value: defaultValue,
+      reason: 'ERROR',
+      errorCode: errorCode,
+      errorMessage: errorMessage,
+      details: error is ProviderException ? error.details : null,
+      evaluatedAt: DateTime.now(),
+      evaluatorId: _provider.metadata.name,
+    );
+  }
+
+  void _recordEvaluationError(ErrorCode? errorCode, Exception error) {
+    final errorKey = errorCode?.name ?? error.runtimeType.toString();
+    _metrics.errorCounts[errorKey] = (_metrics.errorCounts[errorKey] ?? 0) + 1;
+  }
+
+  Future<FlagEvaluationResult<T>> _evaluateFlagResult<T>(
+    String flagKey,
+    T defaultValue,
+    Future<FlagEvaluationResult<T>> Function(Map<String, dynamic>?) evaluator, {
+    Map<String, dynamic>? context,
+  }) async {
+    final startTime = DateTime.now();
+    var effectiveContext = _buildEffectiveContext(context);
+    final hookData = HookData();
+    final flagValueType = _inferFlagValueType(defaultValue);
+    FlagEvaluationResult<T>? finalResult;
+    EvaluationDetails? evaluationDetails;
+    Exception? evaluationError;
+    _metrics.flagEvaluations++;
+
+    try {
+      effectiveContext = await _hookManager.executeHooks(
+        HookStage.BEFORE,
+        flagKey,
+        effectiveContext,
+        clientMetadata: metadata,
+        providerMetadata: _provider.metadata,
+        defaultValue: defaultValue,
+        flagValueType: flagValueType,
+        hookData: hookData,
+      );
+
+      finalResult = await evaluator(effectiveContext);
+      evaluationDetails = _createEvaluationDetails(finalResult);
+
+      if (finalResult.errorCode == null) {
+        await _hookManager.executeHooks(
+          HookStage.AFTER,
+          flagKey,
+          effectiveContext,
+          result: finalResult.value,
+          evaluationDetails: evaluationDetails,
+          clientMetadata: metadata,
+          providerMetadata: _provider.metadata,
+          defaultValue: defaultValue,
+          flagValueType: flagValueType,
+          hookData: hookData,
+        );
+      } else {
+        evaluationError = _providerErrorAsException(finalResult);
+        _logger.warning(
+          'Flag evaluation error for $flagKey: ${finalResult.errorMessage}',
+        );
+        _recordEvaluationError(finalResult.errorCode, evaluationError);
+
+        await _hookManager.executeHooks(
+          HookStage.ERROR,
+          flagKey,
+          effectiveContext,
+          result: finalResult.value,
+          error: evaluationError,
+          evaluationDetails: evaluationDetails,
+          clientMetadata: metadata,
+          providerMetadata: _provider.metadata,
+          defaultValue: defaultValue,
+          flagValueType: flagValueType,
+          hookData: hookData,
+        );
+      }
+    } catch (e) {
+      evaluationError = _asException(e);
+      _logger.warning('Error evaluating flag $flagKey: $e');
+      if (finalResult == null || finalResult.errorCode == null) {
+        finalResult = _exceptionResult(flagKey, defaultValue, evaluationError);
+      }
+      evaluationDetails ??= _createEvaluationDetails(finalResult);
+      _recordEvaluationError(finalResult.errorCode, evaluationError);
+
+      await _hookManager.executeHooks(
+        HookStage.ERROR,
+        flagKey,
+        effectiveContext,
+        result: finalResult.value,
+        error: evaluationError,
+        evaluationDetails: evaluationDetails,
+        clientMetadata: metadata,
+        providerMetadata: _provider.metadata,
+        defaultValue: defaultValue,
+        flagValueType: flagValueType,
+        hookData: hookData,
+      );
+    } finally {
+      _metrics.responseTimes.add(DateTime.now().difference(startTime));
+      if (finalResult != null) {
+        evaluationDetails ??= _createEvaluationDetails(finalResult);
+      }
+      await _hookManager.executeHooks(
+        HookStage.FINALLY,
+        flagKey,
+        effectiveContext,
+        result: finalResult?.value ?? defaultValue,
+        error: evaluationError,
+        evaluationDetails: evaluationDetails,
+        clientMetadata: metadata,
+        providerMetadata: _provider.metadata,
+        defaultValue: defaultValue,
+        flagValueType: flagValueType,
+        hookData: hookData,
+      );
+    }
+
+    return finalResult;
   }
 
   /// Generic flag evaluation orchestrator
@@ -76,93 +294,13 @@ class FeatureClient {
     Future<FlagEvaluationResult<T>> Function(Map<String, dynamic>?) evaluator, {
     Map<String, dynamic>? context,
   }) async {
-    final startTime = DateTime.now();
-    _metrics.flagEvaluations++;
-
-    try {
-      // Build effective context from default, provided, and transaction contexts
-      final effectiveContext = {
-        ..._defaultContext.attributes,
-        ...context ?? {},
-        ..._transactionManager.currentContext?.effectiveAttributes ?? {},
-      };
-
-      // Execute before hooks
-      await _hookManager.executeHooks(
-        HookStage.BEFORE,
-        flagKey,
-        effectiveContext,
-        clientMetadata: metadata,
-        providerMetadata: _provider.metadata,
-      );
-
-      // Delegate to provider (which handles caching)
-      final result = await evaluator(effectiveContext);
-
-      // Execute after hooks
-      await _hookManager.executeHooks(
-        HookStage.AFTER,
-        flagKey,
-        effectiveContext,
-        result: result.value,
-        clientMetadata: metadata,
-        providerMetadata: _provider.metadata,
-      );
-
-      // Track errors from provider
-      if (result.errorCode != null) {
-        _logger.warning(
-          'Flag evaluation error for $flagKey: ${result.errorMessage}',
-        );
-        _metrics.errorCounts[result.errorCode!.name] =
-            (_metrics.errorCounts[result.errorCode!.name] ?? 0) + 1;
-      }
-
-      _metrics.responseTimes.add(DateTime.now().difference(startTime));
-
-      // Publish flag evaluation event to the global event bus
-      OpenFeatureEvents.instance.publish(
-        OpenFeatureEvent(
-          id: '${metadata.name}:$flagKey:${DateTime.now().microsecondsSinceEpoch}',
-          type: OpenFeatureEventType.flagEvaluated,
-          data: {
-            'flagKey': flagKey,
-            'result': result.value,
-            'clientName': metadata.name,
-            'providerName': _provider.metadata.name,
-            if (result.errorCode != null) 'errorCode': result.errorCode!.name,
-            if (result.errorMessage != null)
-              'errorMessage': result.errorMessage,
-          },
-        ),
-      );
-
-      return result.value;
-    } catch (e) {
-      _logger.warning('Error evaluating flag $flagKey: $e');
-      _metrics.errorCounts[e.runtimeType.toString()] =
-          (_metrics.errorCounts[e.runtimeType.toString()] ?? 0) + 1;
-
-      // Execute error hooks
-      await _hookManager.executeHooks(
-        HookStage.ERROR,
-        flagKey,
-        context,
-        error: e is Exception ? e : Exception(e.toString()),
-        clientMetadata: metadata,
-        providerMetadata: _provider.metadata,
-      );
-      return defaultValue;
-    } finally {
-      // Execute finally hooks
-      await _hookManager.executeHooks(
-        HookStage.FINALLY,
-        flagKey,
-        context,
-        clientMetadata: metadata,
-        providerMetadata: _provider.metadata,
-      );
-    }
+    final result = await _evaluateFlagResult(
+      flagKey,
+      defaultValue,
+      evaluator,
+      context: context,
+    );
+    return result.value;
   }
 
   /// Evaluate boolean flag
@@ -225,20 +363,13 @@ class FeatureClient {
   );
 
   /// Tracking API (spec Section 6) - record a tracking event
-  /// Context merging follows: API → transaction → client → invocation
-  /// If the provider does not support tracking, the call silently no-ops.
   Future<void> track(
     String trackingEventName, {
     EvaluationContext? context,
     TrackingEventDetails? trackingDetails,
   }) async {
     _metrics.trackingEvents++;
-
-    final effectiveContext = {
-      ..._defaultContext.attributes,
-      ...context?.attributes ?? {},
-      ..._transactionManager.currentContext?.effectiveAttributes ?? {},
-    };
+    final effectiveContext = _buildEffectiveContext(context?.attributes);
 
     try {
       await _provider.track(
@@ -255,6 +386,11 @@ class FeatureClient {
 
   /// Access to provider for management operations
   FeatureProvider get provider => _provider;
+
+  Future<void> dispose() async {
+    await _eventSubscription?.cancel();
+    await _eventController.close();
+  }
 }
 
 /// Extension to add evaluation details methods
@@ -265,19 +401,11 @@ extension ClientEvaluationDetails on FeatureClient {
     EvaluationContext? context,
     bool defaultValue = false,
   }) async {
-    await getBooleanFlag(flagKey, context: context, defaultValue: defaultValue);
-
-    // Get the result from provider for details
-    final effectiveContext = {
-      ..._defaultContext.attributes,
-      ...context?.attributes ?? {},
-      ..._transactionManager.currentContext?.effectiveAttributes ?? {},
-    };
-
-    final result = await _provider.getBooleanFlag(
+    final result = await _evaluateFlagResult(
       flagKey,
       defaultValue,
-      context: effectiveContext,
+      (ctx) => _provider.getBooleanFlag(flagKey, defaultValue, context: ctx),
+      context: context?.attributes,
     );
 
     return FlagEvaluationDetails.fromResult(result);
@@ -289,18 +417,11 @@ extension ClientEvaluationDetails on FeatureClient {
     EvaluationContext? context,
     String defaultValue = '',
   }) async {
-    await getStringFlag(flagKey, context: context, defaultValue: defaultValue);
-
-    final effectiveContext = {
-      ..._defaultContext.attributes,
-      ...context?.attributes ?? {},
-      ..._transactionManager.currentContext?.effectiveAttributes ?? {},
-    };
-
-    final result = await _provider.getStringFlag(
+    final result = await _evaluateFlagResult(
       flagKey,
       defaultValue,
-      context: effectiveContext,
+      (ctx) => _provider.getStringFlag(flagKey, defaultValue, context: ctx),
+      context: context?.attributes,
     );
 
     return FlagEvaluationDetails.fromResult(result);
@@ -312,18 +433,11 @@ extension ClientEvaluationDetails on FeatureClient {
     EvaluationContext? context,
     int defaultValue = 0,
   }) async {
-    await getIntegerFlag(flagKey, context: context, defaultValue: defaultValue);
-
-    final effectiveContext = {
-      ..._defaultContext.attributes,
-      ...context?.attributes ?? {},
-      ..._transactionManager.currentContext?.effectiveAttributes ?? {},
-    };
-
-    final result = await _provider.getIntegerFlag(
+    final result = await _evaluateFlagResult(
       flagKey,
       defaultValue,
-      context: effectiveContext,
+      (ctx) => _provider.getIntegerFlag(flagKey, defaultValue, context: ctx),
+      context: context?.attributes,
     );
 
     return FlagEvaluationDetails.fromResult(result);
@@ -335,18 +449,11 @@ extension ClientEvaluationDetails on FeatureClient {
     EvaluationContext? context,
     double defaultValue = 0.0,
   }) async {
-    await getDoubleFlag(flagKey, context: context, defaultValue: defaultValue);
-
-    final effectiveContext = {
-      ..._defaultContext.attributes,
-      ...context?.attributes ?? {},
-      ..._transactionManager.currentContext?.effectiveAttributes ?? {},
-    };
-
-    final result = await _provider.getDoubleFlag(
+    final result = await _evaluateFlagResult(
       flagKey,
       defaultValue,
-      context: effectiveContext,
+      (ctx) => _provider.getDoubleFlag(flagKey, defaultValue, context: ctx),
+      context: context?.attributes,
     );
 
     return FlagEvaluationDetails.fromResult(result);
@@ -358,18 +465,11 @@ extension ClientEvaluationDetails on FeatureClient {
     EvaluationContext? context,
     Map<String, dynamic> defaultValue = const {},
   }) async {
-    await getObjectFlag(flagKey, context: context, defaultValue: defaultValue);
-
-    final effectiveContext = {
-      ..._defaultContext.attributes,
-      ...context?.attributes ?? {},
-      ..._transactionManager.currentContext?.effectiveAttributes ?? {},
-    };
-
-    final result = await _provider.getObjectFlag(
+    final result = await _evaluateFlagResult(
       flagKey,
       defaultValue,
-      context: effectiveContext,
+      (ctx) => _provider.getObjectFlag(flagKey, defaultValue, context: ctx),
+      context: context?.attributes,
     );
 
     return FlagEvaluationDetails.fromResult(result);

--- a/lib/hooks.dart
+++ b/lib/hooks.dart
@@ -76,6 +76,7 @@ class EvaluationDetails {
 /// within a single flag evaluation lifecycle.
 class HookData {
   final Map<String, dynamic> _data = {};
+  final Map<Object, HookData> _scopedData = {};
 
   /// Set a value in hook data
   void set(String key, dynamic value) {
@@ -93,12 +94,15 @@ class HookData {
 
   /// Get all entries as an unmodifiable map
   Map<String, dynamic> toMap() => Map.unmodifiable(_data);
+
+  HookData _scopeFor(Object scopeKey) =>
+      _scopedData.putIfAbsent(scopeKey, HookData.new);
 }
 
 /// Context passed to hooks during execution
 class HookContext {
   final String flagKey;
-  final Map<String, dynamic>? evaluationContext;
+  final Map<String, dynamic> evaluationContext;
   final dynamic result;
   final Exception? error;
   final Map<String, dynamic> metadata;
@@ -110,7 +114,7 @@ class HookContext {
 
   HookContext({
     required this.flagKey,
-    this.evaluationContext,
+    Map<String, dynamic>? evaluationContext,
     this.result,
     this.error,
     this.metadata = const {},
@@ -119,7 +123,10 @@ class HookContext {
     this.defaultValue,
     this.flagValueType,
     HookData? hookData,
-  }) : hookData = hookData ?? HookData();
+  }) : evaluationContext = Map.unmodifiable(
+         Map<String, dynamic>.from(evaluationContext ?? const {}),
+       ),
+       hookData = hookData ?? HookData();
 }
 
 /// Optional hints for hook execution
@@ -134,8 +141,11 @@ abstract class Hook {
   /// Hook metadata and configuration
   HookMetadata get metadata;
 
-  /// Before flag evaluation
-  Future<void> before(HookContext context);
+  /// Before flag evaluation.
+  ///
+  /// Returned context updates are merged into the evaluation context before the
+  /// provider is called and before later before hooks execute.
+  Future<Map<String, dynamic>?> before(HookContext context);
 
   /// After successful evaluation
   Future<void> after(HookContext context);
@@ -154,14 +164,10 @@ abstract class Hook {
 /// Manager for hook registration and execution
 class HookManager {
   final List<Hook> _hooks = [];
-  final bool _failFast;
   final Duration _defaultTimeout;
 
-  HookManager({
-    bool failFast = false,
-    Duration defaultTimeout = const Duration(seconds: 5),
-  }) : _failFast = failFast,
-       _defaultTimeout = defaultTimeout;
+  HookManager({Duration defaultTimeout = const Duration(seconds: 5)})
+    : _defaultTimeout = defaultTimeout;
 
   /// Register a new hook
   void addHook(Hook hook) {
@@ -169,8 +175,12 @@ class HookManager {
     _sortHooks();
   }
 
+  void removeHook(Hook hook) {
+    _hooks.remove(hook);
+  }
+
   /// Execute hooks for a specific stage
-  Future<void> executeHooks(
+  Future<Map<String, dynamic>> executeHooks(
     HookStage stage,
     String flagKey,
     Map<String, dynamic>? context, {
@@ -184,22 +194,23 @@ class HookManager {
     FlagValueType? flagValueType,
     HookData? hookData,
   }) async {
-    final sharedHookData = hookData ?? HookData();
-    final hookContext = HookContext(
-      flagKey: flagKey,
-      evaluationContext: context,
-      result: result,
-      error: error,
-      clientMetadata: clientMetadata,
-      providerMetadata: providerMetadata,
-      defaultValue: defaultValue,
-      flagValueType: flagValueType,
-      hookData: sharedHookData,
-    );
+    var currentContext = Map<String, dynamic>.from(context ?? const {});
+    final evaluationHookData = hookData ?? HookData();
+    for (final hook in _hooksForStage(stage)) {
+      final hookContext = HookContext(
+        flagKey: flagKey,
+        evaluationContext: currentContext,
+        result: result,
+        error: error,
+        clientMetadata: clientMetadata,
+        providerMetadata: providerMetadata,
+        defaultValue: defaultValue,
+        flagValueType: flagValueType,
+        hookData: evaluationHookData._scopeFor(hook),
+      );
 
-    for (final hook in _hooks) {
       try {
-        await _executeHookWithTimeout(
+        final contextUpdates = await _executeHookWithTimeout(
           hook,
           stage,
           hookContext,
@@ -207,13 +218,21 @@ class HookManager {
           evaluationDetails,
           hints,
         );
+
+        if (stage == HookStage.BEFORE &&
+            contextUpdates != null &&
+            contextUpdates.isNotEmpty) {
+          currentContext = {...currentContext, ...contextUpdates};
+        }
       } catch (e) {
-        if (_failFast || !hook.metadata.config.continueOnError) {
+        if (stage == HookStage.BEFORE || stage == HookStage.AFTER) {
           rethrow;
         }
         print('Error in ${hook.metadata.name} hook: $e');
       }
     }
+
+    return currentContext;
   }
 
   /// Sort hooks by priority
@@ -223,8 +242,15 @@ class HookManager {
     );
   }
 
+  List<Hook> _hooksForStage(HookStage stage) {
+    if (stage == HookStage.BEFORE) {
+      return List.unmodifiable(_hooks);
+    }
+    return _hooks.reversed.toList(growable: false);
+  }
+
   /// Execute a single hook with timeout
-  Future<void> _executeHookWithTimeout(
+  Future<Map<String, dynamic>?> _executeHookWithTimeout(
     Hook hook,
     HookStage stage,
     HookContext context,
@@ -234,23 +260,32 @@ class HookManager {
   ) async {
     final effectiveTimeout = timeout ?? _defaultTimeout;
 
-    Future<void> hookExecution;
+    Future<Map<String, dynamic>?> hookExecution;
     switch (stage) {
       case HookStage.BEFORE:
         hookExecution = hook.before(context);
         break;
       case HookStage.AFTER:
-        hookExecution = hook.after(context);
+        hookExecution = () async {
+          await hook.after(context);
+          return null;
+        }();
         break;
       case HookStage.ERROR:
-        hookExecution = hook.error(context);
+        hookExecution = () async {
+          await hook.error(context);
+          return null;
+        }();
         break;
       case HookStage.FINALLY:
-        hookExecution = hook.finally_(context, evaluationDetails, hints);
+        hookExecution = () async {
+          await hook.finally_(context, evaluationDetails, hints);
+          return null;
+        }();
         break;
     }
 
-    await hookExecution.timeout(
+    return await hookExecution.timeout(
       effectiveTimeout,
       onTimeout: () {
         throw TimeoutException(
@@ -269,7 +304,7 @@ abstract class BaseHook implements Hook {
   BaseHook({required this.metadata});
 
   @override
-  Future<void> before(HookContext context) async {}
+  Future<Map<String, dynamic>?> before(HookContext context) async => null;
 
   @override
   Future<void> after(HookContext context) async {}
@@ -283,6 +318,124 @@ abstract class BaseHook implements Hook {
     EvaluationDetails? evaluationDetails, [
     HookHints? hints,
   ]) async {}
+}
+
+/// A lightweight hook that emits structured logs for each lifecycle stage.
+class LoggingHook extends BaseHook {
+  final void Function(String message)? logger;
+  final bool includeContext;
+  static const String _circularReferenceMarker = '[Circular]';
+
+  LoggingHook({
+    this.logger,
+    this.includeContext = false,
+    HookPriority priority = HookPriority.NORMAL,
+  }) : super(
+         metadata: HookMetadata(name: 'LoggingHook', priority: priority),
+       );
+
+  Object? _safeJsonValue(dynamic value, [Set<Object>? visited]) {
+    final seen = visited ?? Set<Object>.identity();
+
+    if (value == null || value is num || value is bool || value is String) {
+      return value;
+    }
+
+    if (value is DateTime) {
+      return value.toIso8601String();
+    }
+
+    if (value is Duration) {
+      return value.inMicroseconds;
+    }
+
+    if (value is Enum) {
+      return value.name;
+    }
+
+    if (value is Map) {
+      if (!seen.add(value)) {
+        return _circularReferenceMarker;
+      }
+
+      final jsonSafeMap = <String, Object?>{};
+      value.forEach((key, nestedValue) {
+        jsonSafeMap[key.toString()] = _safeJsonValue(nestedValue, seen);
+      });
+      seen.remove(value);
+      return jsonSafeMap;
+    }
+
+    if (value is Iterable) {
+      if (!seen.add(value)) {
+        return _circularReferenceMarker;
+      }
+
+      final jsonSafeValues = value
+          .map((element) => _safeJsonValue(element, seen))
+          .toList(growable: false);
+      seen.remove(value);
+      return jsonSafeValues;
+    }
+
+    return value.toString();
+  }
+
+  void _writeLog(String message) {
+    if (logger != null) {
+      logger!(message);
+    } else {
+      print(message);
+    }
+  }
+
+  void _log(String stage, HookContext context, [EvaluationDetails? details]) {
+    try {
+      final payload = jsonEncode({
+        'stage': stage,
+        'flagKey': context.flagKey,
+        'provider': context.providerMetadata?.name,
+        'client': context.clientMetadata?.name,
+        if (includeContext)
+          'context': _safeJsonValue(context.evaluationContext),
+        if (!includeContext && context.evaluationContext.isNotEmpty)
+          'contextKeys': context.evaluationContext.keys.toList(growable: false),
+        'result': _safeJsonValue(details?.value ?? context.result),
+        'reason': details?.reason,
+        'error': context.error?.toString(),
+      });
+
+      _writeLog(payload);
+    } catch (error) {
+      final fallbackMessage =
+          'LoggingHook failed to serialize log for stage: '
+          '$stage, flag: ${context.flagKey}. Error: $error';
+      try {
+        _writeLog(fallbackMessage);
+      } catch (_) {
+        // Logging must never interfere with flag evaluation.
+      }
+    }
+  }
+
+  @override
+  Future<Map<String, dynamic>?> before(HookContext context) async {
+    _log('before', context);
+    return null;
+  }
+
+  @override
+  Future<void> after(HookContext context) async => _log('after', context);
+
+  @override
+  Future<void> error(HookContext context) async => _log('error', context);
+
+  @override
+  Future<void> finally_(
+    HookContext context,
+    EvaluationDetails? evaluationDetails, [
+    HookHints? hints,
+  ]) async => _log('finally', context, evaluationDetails);
 }
 
 //

--- a/lib/multi_provider.dart
+++ b/lib/multi_provider.dart
@@ -1,0 +1,322 @@
+import 'feature_provider.dart';
+
+/// Strategy for selecting a result from multiple providers.
+abstract class MultiProviderStrategy {
+  const MultiProviderStrategy();
+
+  Future<FlagEvaluationResult<T>> evaluate<T>({
+    required String flagKey,
+    required T defaultValue,
+    required List<FeatureProvider> providers,
+    required Future<FlagEvaluationResult<T>> Function(FeatureProvider provider)
+    evaluator,
+  });
+}
+
+/// Default Multi-Provider strategy.
+///
+/// Providers are evaluated in order. `FLAG_NOT_FOUND` results are treated as a
+/// miss and the next provider is consulted. The first successful result wins.
+/// If every provider misses, a single `FLAG_NOT_FOUND` result is returned. If
+/// no provider succeeds and at least one provider returns another error, the
+/// first non-`FLAG_NOT_FOUND` error is returned.
+class FirstMatchStrategy extends MultiProviderStrategy {
+  const FirstMatchStrategy();
+
+  @override
+  Future<FlagEvaluationResult<T>> evaluate<T>({
+    required String flagKey,
+    required T defaultValue,
+    required List<FeatureProvider> providers,
+    required Future<FlagEvaluationResult<T>> Function(FeatureProvider provider)
+    evaluator,
+  }) async {
+    FlagEvaluationResult<T>? firstError;
+
+    for (final provider in providers) {
+      final result = await evaluator(provider);
+      if (result.errorCode == null) {
+        return result;
+      }
+
+      if (result.errorCode != ErrorCode.FLAG_NOT_FOUND) {
+        firstError ??= result;
+      }
+    }
+
+    return firstError ??
+        FlagEvaluationResult.error(
+          flagKey,
+          defaultValue,
+          ErrorCode.FLAG_NOT_FOUND,
+          'Flag "$flagKey" was not found in any configured provider.',
+          evaluatorId: 'MultiProvider',
+        );
+  }
+}
+
+/// Experimental SDK-level utility for composing multiple providers behind one
+/// spec-compliant provider interface.
+class MultiProvider implements FeatureProvider {
+  final List<FeatureProvider> _providers;
+  final MultiProviderStrategy _strategy;
+  final ProviderConfig _config;
+  final ProviderMetadata _metadata;
+
+  MultiProvider(
+    List<FeatureProvider> providers, {
+    MultiProviderStrategy strategy = const FirstMatchStrategy(),
+    ProviderConfig config = const ProviderConfig(),
+    ProviderMetadata metadata = const ProviderMetadata(
+      name: 'MultiProvider',
+      version: '0.1.0',
+    ),
+  }) : assert(
+         providers.length > 0,
+         'MultiProvider requires at least one provider',
+       ),
+       _providers = List.unmodifiable(providers),
+       _strategy = strategy,
+       _config = config,
+       _metadata = metadata;
+
+  List<FeatureProvider> get providers => _providers;
+
+  @override
+  String get name => _metadata.name;
+
+  @override
+  ProviderConfig get config => _config;
+
+  @override
+  ProviderMetadata get metadata => _metadata;
+
+  @override
+  ProviderState get state => _aggregateState(_providers.map((p) => p.state));
+
+  @override
+  Future<void> initialize([Map<String, dynamic>? config]) async {
+    final errors = await _collectErrors(
+      _providers.map(
+        (provider) async {
+          if (provider.state == ProviderState.NOT_READY) {
+            await provider.initialize(config);
+          }
+        },
+      ),
+    );
+
+    _throwIfNoProviderReady(errors, 'initialize');
+  }
+
+  @override
+  Future<void> connect() async {
+    final errors = await _collectErrors(
+      _providers.map((provider) => provider.connect()),
+    );
+
+    _throwIfNoProviderReady(errors, 'connect');
+  }
+
+  @override
+  Future<void> shutdown() async {
+    final errors = <Object>[];
+    for (final provider in _providers) {
+      try {
+        await provider.shutdown();
+      } catch (error) {
+        errors.add(error);
+      }
+    }
+
+    if (errors.isNotEmpty) {
+      throw ProviderException(
+        'One or more providers failed to shut down.',
+        code: ErrorCode.GENERAL,
+        details: {'errors': errors.map((e) => e.toString()).toList()},
+      );
+    }
+  }
+
+  @override
+  Future<void> track(
+    String trackingEventName, {
+    Map<String, dynamic>? evaluationContext,
+    TrackingEventDetails? trackingDetails,
+  }) async {
+    await _collectErrors(
+      _providers.map(
+        (provider) => provider.track(
+          trackingEventName,
+          evaluationContext: evaluationContext,
+          trackingDetails: trackingDetails,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Future<FlagEvaluationResult<bool>> getBooleanFlag(
+    String flagKey,
+    bool defaultValue, {
+    Map<String, dynamic>? context,
+  }) => _evaluate(
+    flagKey,
+    defaultValue,
+    (provider) =>
+        provider.getBooleanFlag(flagKey, defaultValue, context: context),
+  );
+
+  @override
+  Future<FlagEvaluationResult<String>> getStringFlag(
+    String flagKey,
+    String defaultValue, {
+    Map<String, dynamic>? context,
+  }) => _evaluate(
+    flagKey,
+    defaultValue,
+    (provider) =>
+        provider.getStringFlag(flagKey, defaultValue, context: context),
+  );
+
+  @override
+  Future<FlagEvaluationResult<int>> getIntegerFlag(
+    String flagKey,
+    int defaultValue, {
+    Map<String, dynamic>? context,
+  }) => _evaluate(
+    flagKey,
+    defaultValue,
+    (provider) =>
+        provider.getIntegerFlag(flagKey, defaultValue, context: context),
+  );
+
+  @override
+  Future<FlagEvaluationResult<double>> getDoubleFlag(
+    String flagKey,
+    double defaultValue, {
+    Map<String, dynamic>? context,
+  }) => _evaluate(
+    flagKey,
+    defaultValue,
+    (provider) =>
+        provider.getDoubleFlag(flagKey, defaultValue, context: context),
+  );
+
+  @override
+  Future<FlagEvaluationResult<Map<String, dynamic>>> getObjectFlag(
+    String flagKey,
+    Map<String, dynamic> defaultValue, {
+    Map<String, dynamic>? context,
+  }) => _evaluate(
+    flagKey,
+    defaultValue,
+    (provider) =>
+        provider.getObjectFlag(flagKey, defaultValue, context: context),
+  );
+
+  Future<FlagEvaluationResult<T>> _evaluate<T>(
+    String flagKey,
+    T defaultValue,
+    Future<FlagEvaluationResult<T>> Function(FeatureProvider provider)
+    evaluator,
+  ) async {
+    final result = await _strategy.evaluate(
+      flagKey: flagKey,
+      defaultValue: defaultValue,
+      providers: _providers,
+      evaluator: evaluator,
+    );
+
+    if (result.evaluatorId.isNotEmpty) {
+      return result;
+    }
+
+    return FlagEvaluationResult<T>(
+      flagKey: result.flagKey,
+      value: result.value,
+      reason: result.reason,
+      variant: result.variant,
+      errorCode: result.errorCode,
+      errorMessage: result.errorMessage,
+      details: result.details,
+      evaluatedAt: result.evaluatedAt,
+      evaluatorId: name,
+    );
+  }
+
+  Future<List<Object>> _collectErrors(
+    Iterable<Future<void>> operations,
+  ) async {
+    final results = await Future.wait<Object?>(
+      operations.map((operation) async {
+        try {
+          await operation;
+          return null;
+        } catch (error) {
+          return error;
+        }
+      }),
+    );
+
+    return results.whereType<Object>().toList(growable: false);
+  }
+
+  void _throwIfNoProviderReady(List<Object> errors, String operation) {
+    if (_providers.any((provider) => provider.state == ProviderState.READY)) {
+      return;
+    }
+
+    if (errors.isEmpty) {
+      throw ProviderException(
+        'No provider reached READY state during $operation.',
+        code: ErrorCode.PROVIDER_NOT_READY,
+      );
+    }
+
+    throw ProviderException(
+      'No provider reached READY state during $operation.',
+      code: ErrorCode.PROVIDER_NOT_READY,
+      details: {'errors': errors.map((e) => e.toString()).toList()},
+    );
+  }
+
+  ProviderState _aggregateState(Iterable<ProviderState> states) {
+    final normalizedStates = states.map(_normalizeState).toList();
+    if (normalizedStates.contains(ProviderState.FATAL)) {
+      return ProviderState.FATAL;
+    }
+    if (normalizedStates.contains(ProviderState.NOT_READY)) {
+      return ProviderState.NOT_READY;
+    }
+    if (normalizedStates.contains(ProviderState.ERROR)) {
+      return ProviderState.ERROR;
+    }
+    if (normalizedStates.contains(ProviderState.STALE)) {
+      return ProviderState.STALE;
+    }
+    return ProviderState.READY;
+  }
+
+  ProviderState _normalizeState(ProviderState state) {
+    switch (state) {
+      case ProviderState.FATAL:
+        return ProviderState.FATAL;
+      case ProviderState.NOT_READY:
+      case ProviderState.CONNECTING:
+      case ProviderState.SHUTDOWN:
+        return ProviderState.NOT_READY;
+      case ProviderState.ERROR:
+      case ProviderState.DEGRADED:
+      case ProviderState.RECONNECTING:
+      case ProviderState.PLUGIN_ERROR:
+        return ProviderState.ERROR;
+      case ProviderState.STALE:
+      case ProviderState.SYNCHRONIZING:
+      case ProviderState.MAINTENANCE:
+        return ProviderState.STALE;
+      case ProviderState.READY:
+        return ProviderState.READY;
+    }
+  }
+}

--- a/lib/open_feature_api.dart
+++ b/lib/open_feature_api.dart
@@ -1,11 +1,12 @@
 import 'dart:async';
 import 'package:logging/logging.dart';
-import 'domain_manager.dart';
-import 'feature_provider.dart';
-import 'open_feature_event.dart';
 import 'client.dart';
-import 'hooks.dart';
+import 'domain.dart';
+import 'domain_manager.dart';
 import 'evaluation_context.dart';
+import 'feature_provider.dart';
+import 'hooks.dart';
+import 'open_feature_event.dart';
 
 class OpenFeatureEvaluationContext {
   final Map<String, dynamic> attributes;
@@ -138,10 +139,11 @@ class OpenFeatureAPI {
   static OpenFeatureAPI? _instance;
 
   late FeatureProvider _provider;
+  final Map<String, FeatureProvider> _providerRegistry = {};
   final DomainManager _domainManager = DomainManager();
-  final Map<String, FeatureProvider> _domainProviders = {};
   final List<OpenFeatureHook> _hooks = [];
   OpenFeatureEvaluationContext? _globalContext;
+  StreamSubscription<Domain>? _domainSubscription;
 
   final StreamController<FeatureProvider> _providerStreamController;
   final StreamController<OpenFeatureEvent> _eventStreamController;
@@ -153,6 +155,12 @@ class OpenFeatureAPI {
       _domainUpdatesController =
           StreamController<Map<String, String>>.broadcast() {
     _configureLogging();
+    _domainSubscription = _domainManager.domainUpdates.listen((domain) {
+      _domainUpdatesController.add({
+        'clientId': domain.clientId,
+        'providerName': domain.providerName,
+      });
+    });
     _initializeDefaultProvider();
   }
 
@@ -170,47 +178,73 @@ class OpenFeatureAPI {
     });
   }
 
+  ErrorCode? _errorCodeFrom(Object? error, {ProviderState? state}) {
+    if (error is ProviderException) {
+      return error.code;
+    }
+
+    switch (state) {
+      case ProviderState.FATAL:
+        return ErrorCode.PROVIDER_FATAL;
+      case ProviderState.NOT_READY:
+      case ProviderState.CONNECTING:
+      case ProviderState.RECONNECTING:
+      case ProviderState.SHUTDOWN:
+        return ErrorCode.PROVIDER_NOT_READY;
+      default:
+        return null;
+    }
+  }
+
   void _initializeDefaultProvider() {
     _provider = _ImmediateReadyProvider();
+    _providerRegistry[_provider.metadata.name] = _provider;
     _logger.info('Default provider initialized and ready');
-    _emitEvent(OpenFeatureEventType.PROVIDER_READY, 'Default provider ready');
+    _emitEvent(
+      OpenFeatureEventType.PROVIDER_READY,
+      'Default provider ready',
+      providerMetadata: _provider.metadata,
+    );
   }
 
   Future<void> setProvider(FeatureProvider provider) async {
     _logger.info('Setting provider: ${provider.name}');
 
     try {
-      // Only initialize if provider is NOT_READY
       if (provider.state == ProviderState.NOT_READY) {
         await provider.initialize();
       }
 
       _provider = provider;
+      _providerRegistry[provider.metadata.name] = provider;
       _providerStreamController.add(provider);
 
-      // Emit appropriate event based on state
       if (provider.state == ProviderState.READY) {
         _emitEvent(
           OpenFeatureEventType.PROVIDER_READY,
           'Provider ready: ${provider.name}',
+          providerMetadata: provider.metadata,
         );
       } else {
         _emitEvent(
           OpenFeatureEventType.PROVIDER_ERROR,
           'Provider not ready: ${provider.name}',
           data: {'state': provider.state.name},
+          providerMetadata: provider.metadata,
+          errorCode: _errorCodeFrom(null, state: provider.state),
         );
       }
     } catch (error) {
       _logger.severe('Failed to initialize provider: $error');
-
-      // Per OpenFeature spec: keep provider in ERROR state
       _provider = provider;
+      _providerRegistry[provider.metadata.name] = provider;
       _providerStreamController.add(provider);
       _emitEvent(
         OpenFeatureEventType.PROVIDER_ERROR,
         'Provider initialization failed: ${provider.name}',
         data: error,
+        providerMetadata: provider.metadata,
+        errorCode: _errorCodeFrom(error),
       );
     }
   }
@@ -220,12 +254,10 @@ class OpenFeatureAPI {
     _logger.info('Setting provider and waiting: ${provider.name}');
 
     try {
-      // Initialize if needed
       if (provider.state == ProviderState.NOT_READY) {
         await provider.initialize();
       }
 
-      // Wait for READY state
       if (provider.state != ProviderState.READY) {
         throw ProviderException(
           'Provider failed to reach READY state: ${provider.state}',
@@ -234,22 +266,31 @@ class OpenFeatureAPI {
       }
 
       _provider = provider;
+      _providerRegistry[provider.metadata.name] = provider;
       _providerStreamController.add(provider);
       _emitEvent(
         OpenFeatureEventType.PROVIDER_READY,
         'Provider ready: ${provider.name}',
+        providerMetadata: provider.metadata,
       );
     } catch (error) {
       _logger.severe('Failed to initialize provider: $error');
       _provider = provider;
+      _providerRegistry[provider.metadata.name] = provider;
       _providerStreamController.add(provider);
       _emitEvent(
         OpenFeatureEventType.PROVIDER_ERROR,
         'Provider initialization failed: ${provider.name}',
         data: error,
+        providerMetadata: provider.metadata,
+        errorCode: _errorCodeFrom(error),
       );
       rethrow;
     }
+  }
+
+  void registerProvider(FeatureProvider provider) {
+    _providerRegistry[provider.metadata.name] = provider;
   }
 
   /// Shutdown the current provider (spec v0.8.0: status MUST indicate NOT_READY after shutdown)
@@ -261,6 +302,7 @@ class OpenFeatureAPI {
       _emitEvent(
         OpenFeatureEventType.PROVIDER_STALE,
         'Provider shutdown: ${_provider.name}',
+        providerMetadata: _provider.metadata,
       );
     } catch (e) {
       _logger.severe('Error during provider shutdown: $e');
@@ -268,71 +310,42 @@ class OpenFeatureAPI {
         OpenFeatureEventType.PROVIDER_ERROR,
         'Provider shutdown failed: ${_provider.name}',
         data: e,
+        providerMetadata: _provider.metadata,
+        errorCode: _errorCodeFrom(e),
       );
     }
 
     _initializeDefaultProvider();
   }
 
-  /// Register a provider for a specific domain. Clients requested with this
-  /// domain will be backed by the given provider instead of the default one.
-  Future<void> setProviderForDomain(
-    String domain,
-    FeatureProvider provider,
-  ) async {
-    _logger.info('Setting provider for domain "$domain": ${provider.name}');
-
-    try {
-      if (provider.state == ProviderState.NOT_READY) {
-        await provider.initialize();
-      }
-
-      _domainProviders[domain] = provider;
-
-      if (provider.state == ProviderState.READY) {
-        _emitEvent(
-          OpenFeatureEventType.PROVIDER_READY,
-          'Provider ready for domain "$domain": ${provider.name}',
-        );
-      } else {
-        _emitEvent(
-          OpenFeatureEventType.PROVIDER_ERROR,
-          'Provider not ready for domain "$domain": ${provider.name}',
-          data: {'state': provider.state.name},
-        );
-      }
-    } catch (error) {
-      _logger.severe('Failed to initialize provider for domain "$domain": $error');
-      _domainProviders[domain] = provider;
-      _emitEvent(
-        OpenFeatureEventType.PROVIDER_ERROR,
-        'Provider initialization failed for domain "$domain": ${provider.name}',
-        data: {'error': error.toString()},
-      );
+  FeatureProvider _resolveProviderForClient(String clientId, String? domain) {
+    final bindingKey = domain ?? clientId;
+    final boundProviderName = _domainManager.getProviderForClient(bindingKey);
+    if (boundProviderName == null) {
+      return _provider;
     }
+
+    return _providerRegistry[boundProviderName] ?? _provider;
   }
 
-  /// Get or create a client. If [domain] is provided and a provider was
-  /// registered for that domain via [setProviderForDomain], the client is
-  /// backed by that provider; otherwise it falls back to the default provider.
+  /// Get or create a client
   FeatureClient getClient(String name, {String? domain}) {
-    final resolvedProvider =
-        (domain != null ? _domainProviders[domain] : null) ?? _provider;
+    final selectedProvider = _resolveProviderForClient(name, domain);
 
-    // Build hook manager with global hooks
     final hookManager = HookManager();
     for (final hook in _hooks) {
-      // Convert OpenFeatureHook to Hook if needed
       hookManager.addHook(_wrapHook(hook));
     }
 
     return FeatureClient(
       metadata: ClientMetadata(name: name),
       hookManager: hookManager,
-      defaultContext: _globalContext != null
+      apiContext: _globalContext != null
           ? EvaluationContext(attributes: _globalContext!.attributes)
-          : EvaluationContext(attributes: {}),
-      provider: resolvedProvider,
+          : const EvaluationContext(attributes: {}),
+      defaultContext: const EvaluationContext(attributes: {}),
+      provider: selectedProvider,
+      eventStream: events,
     );
   }
 
@@ -349,6 +362,7 @@ class OpenFeatureAPI {
     _emitEvent(
       OpenFeatureEventType.PROVIDER_CONTEXT_CHANGED,
       'Global context updated',
+      providerMetadata: _provider.metadata,
     );
   }
 
@@ -360,17 +374,25 @@ class OpenFeatureAPI {
 
   List<OpenFeatureHook> get hooks => List.unmodifiable(_hooks);
 
+  StreamSubscription<OpenFeatureEvent> addHandler(
+    void Function(OpenFeatureEvent event) handler,
+  ) => events.listen(handler);
+
+  Future<void> removeHandler(StreamSubscription<OpenFeatureEvent> handler) =>
+      handler.cancel();
+
   void bindClientToProvider(String clientId, String providerId) {
     _domainManager.bindClientToProvider(clientId, providerId);
     _emitEvent(
       OpenFeatureEventType.PROVIDER_CONFIGURATION_CHANGED,
       'Client $clientId bound to provider $providerId',
+      providerMetadata: _providerRegistry[providerId]?.metadata,
     );
   }
 
-  /// @deprecated Use getClient().getBooleanValue() instead
+  /// @deprecated Use getClient().getBooleanFlag() instead
   /// This method exists for backwards compatibility only
-  @Deprecated('Use getClient().getBooleanValue() instead')
+  @Deprecated('Use getClient().getBooleanFlag() instead')
   Future<bool> evaluateBooleanFlag(
     String flagKey,
     String clientId, {
@@ -384,23 +406,26 @@ class OpenFeatureAPI {
     );
   }
 
-  void _emitEvent(OpenFeatureEventType type, String message, {dynamic data}) {
-    final event = OpenFeatureEvent(type, message, data: data);
+  void _emitEvent(
+    OpenFeatureEventType type,
+    String message, {
+    dynamic data,
+    ProviderMetadata? providerMetadata,
+    ErrorCode? errorCode,
+  }) {
+    final event = OpenFeatureEvent(
+      type,
+      message,
+      data: data,
+      providerMetadata: providerMetadata,
+      errorCode: errorCode,
+    );
     _eventStreamController.add(event);
   }
 
   Future<void> dispose() async {
-    for (final entry in _domainProviders.entries) {
-      try {
-        await entry.value.shutdown();
-      } catch (e) {
-        _logger.warning(
-          'Error shutting down provider for domain "${entry.key}": $e',
-        );
-      }
-    }
-    _domainProviders.clear();
-
+    await _domainSubscription?.cancel();
+    _domainManager.dispose();
     await _providerStreamController.close();
     await _eventStreamController.close();
     await _domainUpdatesController.close();
@@ -425,8 +450,9 @@ class _OpenFeatureHookAdapter extends BaseHook {
     : super(metadata: HookMetadata(name: 'OpenFeatureHookAdapter'));
 
   @override
-  Future<void> before(HookContext context) async {
+  Future<Map<String, dynamic>?> before(HookContext context) async {
     _hook.beforeEvaluation(context.flagKey, context.evaluationContext);
+    return null;
   }
 
   @override

--- a/lib/open_feature_event.dart
+++ b/lib/open_feature_event.dart
@@ -1,4 +1,4 @@
-import 'package:openfeature_dart_server_sdk/feature_provider.dart';
+import 'feature_provider.dart';
 
 /// OpenFeature specification-compliant event types
 enum OpenFeatureEventType {

--- a/lib/transaction_context.dart
+++ b/lib/transaction_context.dart
@@ -36,12 +36,21 @@ class TransactionContext {
 class TransactionContextManager {
   static final TransactionContextManager _instance =
       TransactionContextManager._internal();
-  final _contexts = <String, TransactionContext>{};
-  final _contextStack = <String>[];
+  static final Object _zoneContextsKey = Object();
+  static final Object _zoneStackKey = Object();
+  final _fallbackContexts = <String, TransactionContext>{};
+  final _fallbackStack = <String>[];
 
   TransactionContextManager._internal();
 
   factory TransactionContextManager() => _instance;
+
+  Map<String, TransactionContext> get _contexts =>
+      Zone.current[_zoneContextsKey] as Map<String, TransactionContext>? ??
+      _fallbackContexts;
+
+  List<String> get _contextStack =>
+      Zone.current[_zoneStackKey] as List<String>? ?? _fallbackStack;
 
   TransactionContext? get currentContext {
     if (_contextStack.isEmpty) return null;
@@ -88,17 +97,29 @@ class TransactionContextManager {
     Map<String, dynamic> attributes,
     Future<T> Function() operation,
   ) async {
-    final context = TransactionContext(
-      transactionId: transactionId,
-      attributes: attributes,
-    );
+    final zoneContexts = Map<String, TransactionContext>.from(_contexts);
+    final zoneStack = List<String>.from(_contextStack);
 
-    pushContext(context);
-    try {
-      return await operation();
-    } finally {
-      popContext();
-    }
+    return await runZoned(
+      () async {
+        final context = TransactionContext(
+          transactionId: transactionId,
+          attributes: attributes,
+          parent: currentContext,
+        );
+
+        pushContext(context);
+        try {
+          return await operation();
+        } finally {
+          popContext();
+        }
+      },
+      zoneValues: {
+        _zoneContextsKey: zoneContexts,
+        _zoneStackKey: zoneStack,
+      },
+    );
   }
 
   void cleanup() {

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -1,12 +1,16 @@
+import 'dart:async';
 import 'package:test/test.dart';
 import '../lib/client.dart';
 import '../lib/feature_provider.dart';
 import '../lib/evaluation_context.dart';
 import '../lib/hooks.dart';
+import '../lib/open_feature_event.dart';
+import '../lib/transaction_context.dart';
 
 class MockProvider implements FeatureProvider {
   final Map<String, dynamic> flags;
   ProviderState _state = ProviderState.READY;
+  int booleanCalls = 0;
 
   MockProvider(this.flags);
 
@@ -48,6 +52,7 @@ class MockProvider implements FeatureProvider {
     bool defaultValue, {
     Map<String, dynamic>? context,
   }) async {
+    booleanCalls++;
     if (!flags.containsKey(flagKey)) {
       return FlagEvaluationResult.error(
         flagKey,
@@ -139,6 +144,89 @@ class MockProvider implements FeatureProvider {
     Map<String, dynamic>? context,
   }) async {
     throw UnimplementedError();
+  }
+}
+
+class TrackingMockProvider extends MockProvider {
+  Map<String, dynamic>? lastTrackingContext;
+
+  TrackingMockProvider(super.flags);
+
+  @override
+  Future<void> track(
+    String trackingEventName, {
+    Map<String, dynamic>? evaluationContext,
+    TrackingEventDetails? trackingDetails,
+  }) async {
+    lastTrackingContext = evaluationContext;
+  }
+}
+
+class ContextCapturingProvider extends MockProvider {
+  Map<String, dynamic>? lastEvaluationContext;
+
+  ContextCapturingProvider(super.flags);
+
+  @override
+  Future<FlagEvaluationResult<bool>> getBooleanFlag(
+    String flagKey,
+    bool defaultValue, {
+    Map<String, dynamic>? context,
+  }) async {
+    lastEvaluationContext = context == null ? null : {...context};
+    return super.getBooleanFlag(flagKey, defaultValue, context: context);
+  }
+}
+
+class ThrowingProvider extends MockProvider {
+  final ProviderException exception;
+
+  ThrowingProvider(super.flags, this.exception);
+
+  @override
+  Future<FlagEvaluationResult<bool>> getBooleanFlag(
+    String flagKey,
+    bool defaultValue, {
+    Map<String, dynamic>? context,
+  }) async {
+    throw exception;
+  }
+}
+
+class LifecycleHook extends BaseHook {
+  final List<String> calls = [];
+  EvaluationDetails? finalDetails;
+  Exception? lastError;
+  final Map<String, dynamic>? beforeUpdates;
+
+  LifecycleHook({this.beforeUpdates})
+    : super(metadata: HookMetadata(name: 'LifecycleHook'));
+
+  @override
+  Future<Map<String, dynamic>?> before(HookContext context) async {
+    calls.add('before');
+    return beforeUpdates;
+  }
+
+  @override
+  Future<void> after(HookContext context) async {
+    calls.add('after');
+  }
+
+  @override
+  Future<void> error(HookContext context) async {
+    calls.add('error');
+    lastError = context.error;
+  }
+
+  @override
+  Future<void> finally_(
+    HookContext context,
+    EvaluationDetails? evaluationDetails, [
+    HookHints? hints,
+  ]) async {
+    calls.add('finally');
+    finalDetails = evaluationDetails;
   }
 }
 
@@ -258,6 +346,157 @@ void main() {
 
     test('provider metadata is accessible through client', () {
       expect(client.provider.metadata.name, equals('MockProvider'));
+    });
+
+    test('get details evaluates provider only once', () async {
+      final details = await client.getBooleanDetails('test-flag');
+
+      expect(details.value, isTrue);
+      expect(provider.booleanCalls, equals(1));
+    });
+
+    test('tracking merges api, transaction, client, and invocation contexts', () async {
+      final trackingProvider = TrackingMockProvider({'test-flag': true});
+      final transactionManager = TransactionContextManager();
+      client = FeatureClient(
+        metadata: ClientMetadata(name: 'test-client'),
+        hookManager: hookManager,
+        apiContext: const EvaluationContext(
+          attributes: {'global': 'value'},
+        ),
+        defaultContext: const EvaluationContext(
+          attributes: {'client': 'value'},
+        ),
+        provider: trackingProvider,
+        transactionManager: transactionManager,
+      );
+
+      await transactionManager.withContext('tx', {'requestId': '123'}, () async {
+        await client.track(
+          'checkout',
+          context: const EvaluationContext(attributes: {'userId': 'u-1'}),
+        );
+      });
+
+      expect(trackingProvider.lastTrackingContext?['global'], equals('value'));
+      expect(trackingProvider.lastTrackingContext?['requestId'], equals('123'));
+      expect(trackingProvider.lastTrackingContext?['client'], equals('value'));
+      expect(trackingProvider.lastTrackingContext?['userId'], equals('u-1'));
+    });
+
+    test('client handlers receive forwarded events', () async {
+      final controller = StreamController<OpenFeatureEvent>.broadcast();
+      final received = <OpenFeatureEvent>[];
+
+      client = FeatureClient(
+        metadata: ClientMetadata(name: 'test-client'),
+        hookManager: hookManager,
+        defaultContext: context,
+        provider: provider,
+        eventStream: controller.stream,
+      );
+
+      final sub = client.addHandler(received.add);
+      controller.add(
+        OpenFeatureEvent(
+          OpenFeatureEventType.PROVIDER_READY,
+          'ready',
+          providerMetadata: provider.metadata,
+        ),
+      );
+
+      await Future.delayed(const Duration(milliseconds: 10));
+      expect(received, hasLength(1));
+
+      await sub.cancel();
+      await client.dispose();
+      await controller.close();
+    });
+
+    test('provider error result triggers error hooks instead of after hooks', () async {
+      final lifecycleHook = LifecycleHook();
+      hookManager.addHook(lifecycleHook);
+
+      final result = await client.getBooleanFlag(
+        'missing-flag',
+        defaultValue: false,
+      );
+
+      expect(result, isFalse);
+      expect(lifecycleHook.calls, equals(['before', 'error', 'finally']));
+      expect(lifecycleHook.finalDetails?.value, isFalse);
+      expect(lifecycleHook.lastError, isA<ProviderException>());
+      expect(
+        (lifecycleHook.lastError as ProviderException).code,
+        equals(ErrorCode.FLAG_NOT_FOUND),
+      );
+    });
+
+    test('preserves ProviderException error codes from thrown provider errors', () async {
+      final throwingProvider = ThrowingProvider(
+        {'test-flag': true},
+        const ProviderException(
+          'provider unavailable',
+          code: ErrorCode.PROVIDER_NOT_READY,
+        ),
+      );
+
+      client = FeatureClient(
+        metadata: ClientMetadata(name: 'test-client'),
+        hookManager: hookManager,
+        defaultContext: context,
+        provider: throwingProvider,
+      );
+
+      final details = await client.getBooleanDetails(
+        'test-flag',
+        defaultValue: false,
+      );
+
+      expect(details.value, isFalse);
+      expect(details.errorCode, equals(ErrorCode.PROVIDER_NOT_READY));
+      expect(details.errorMessage, equals('provider unavailable'));
+    });
+
+    test('before hook context updates are merged into provider evaluation context', () async {
+      final capturingProvider = ContextCapturingProvider({'test-flag': true});
+      final transactionManager = TransactionContextManager();
+      final lifecycleHook = LifecycleHook(
+        beforeUpdates: {'hook': 'value', 'userId': 'hook-user'},
+      );
+      hookManager.addHook(lifecycleHook);
+
+      client = FeatureClient(
+        metadata: ClientMetadata(name: 'test-client'),
+        hookManager: hookManager,
+        apiContext: const EvaluationContext(
+          attributes: {'global': 'value'},
+        ),
+        defaultContext: const EvaluationContext(
+          attributes: {'client': 'value'},
+        ),
+        provider: capturingProvider,
+        transactionManager: transactionManager,
+      );
+
+      await transactionManager.withContext('tx', {'requestId': '123'}, () async {
+        await client.getBooleanFlag(
+          'test-flag',
+          context: const EvaluationContext(attributes: {'userId': 'invocation'}),
+        );
+      });
+
+      expect(capturingProvider.lastEvaluationContext?['global'], equals('value'));
+      expect(
+        capturingProvider.lastEvaluationContext?['requestId'],
+        equals('123'),
+      );
+      expect(capturingProvider.lastEvaluationContext?['client'], equals('value'));
+      expect(capturingProvider.lastEvaluationContext?['hook'], equals('value'));
+      expect(
+        capturingProvider.lastEvaluationContext?['userId'],
+        equals('hook-user'),
+      );
     });
   });
 }

--- a/test/hooks_test.dart
+++ b/test/hooks_test.dart
@@ -2,24 +2,36 @@ import 'dart:async';
 import 'package:test/test.dart';
 import '../lib/hooks.dart';
 
+class BrokenStringify {
+  @override
+  String toString() => throw StateError('broken toString');
+}
+
 class TestHook implements Hook {
   final List<String> executionOrder = [];
   final HookPriority _priority;
   bool receivedEvaluationDetails = false;
+  HookData? beforeHookData;
+  HookData? afterHookData;
+  final Map<String, dynamic>? _beforeUpdates;
 
-  TestHook([this._priority = HookPriority.NORMAL]);
+  TestHook([this._priority = HookPriority.NORMAL, this._beforeUpdates]);
 
   @override
   HookMetadata get metadata =>
       HookMetadata(name: 'TestHook', priority: _priority);
 
   @override
-  Future<void> before(HookContext context) async {
+  Future<Map<String, dynamic>?> before(HookContext context) async {
+    beforeHookData = context.hookData;
+    context.hookData.set('fromBefore', true);
     executionOrder.add('before');
+    return _beforeUpdates;
   }
 
   @override
   Future<void> after(HookContext context) async {
+    afterHookData = context.hookData;
     executionOrder.add('after');
   }
 
@@ -44,6 +56,94 @@ class TestHook implements Hook {
   }
 }
 
+class NamedHook extends BaseHook {
+  final String name;
+  final List<String> calls;
+
+  NamedHook(this.name, this.calls, HookPriority priority)
+    : super(
+        metadata: HookMetadata(name: name, priority: priority),
+      );
+
+  @override
+  Future<Map<String, dynamic>?> before(HookContext context) async {
+    calls.add('before:$name');
+    return null;
+  }
+
+  @override
+  Future<void> after(HookContext context) async {
+    calls.add('after:$name');
+  }
+
+  @override
+  Future<void> error(HookContext context) async {
+    calls.add('error:$name');
+  }
+
+  @override
+  Future<void> finally_(
+    HookContext context,
+    EvaluationDetails? evaluationDetails, [
+    HookHints? hints,
+  ]) async {
+    calls.add('finally:$name');
+  }
+}
+
+class ThrowingHook extends BaseHook {
+  final List<String> calls;
+  final String stageToThrow;
+  final String name;
+  final HookPriority priority;
+
+  ThrowingHook({
+    required this.calls,
+    required this.stageToThrow,
+    required this.name,
+    this.priority = HookPriority.NORMAL,
+  }) : super(
+         metadata: HookMetadata(name: name, priority: priority),
+       );
+
+  @override
+  Future<Map<String, dynamic>?> before(HookContext context) async {
+    calls.add('before:$name');
+    if (stageToThrow == 'before') {
+      throw Exception('before failed');
+    }
+    return null;
+  }
+
+  @override
+  Future<void> after(HookContext context) async {
+    calls.add('after:$name');
+    if (stageToThrow == 'after') {
+      throw Exception('after failed');
+    }
+  }
+
+  @override
+  Future<void> error(HookContext context) async {
+    calls.add('error:$name');
+    if (stageToThrow == 'error') {
+      throw Exception('error failed');
+    }
+  }
+
+  @override
+  Future<void> finally_(
+    HookContext context,
+    EvaluationDetails? evaluationDetails, [
+    HookHints? hints,
+  ]) async {
+    calls.add('finally:$name');
+    if (stageToThrow == 'finally') {
+      throw Exception('finally failed');
+    }
+  }
+}
+
 class OTelTestHook extends OpenTelemetryHook {
   final List<Map<String, dynamic>> capturedAttributes = [];
 
@@ -59,16 +159,15 @@ class OTelTestHook extends OpenTelemetryHook {
     EvaluationDetails? evaluationDetails, [
     HookHints? hints,
   ]) async {
-    final otelAttributes =
-        evaluationDetails != null
-            ? OpenTelemetryUtil.fromEvaluationDetails(
-              evaluationDetails,
-              providerName: providerName,
-            )
-            : OpenTelemetryUtil.fromHookContext(
-              context,
-              providerName: providerName,
-            );
+    final otelAttributes = evaluationDetails != null
+        ? OpenTelemetryUtil.fromEvaluationDetails(
+            evaluationDetails,
+            providerName: providerName,
+          )
+        : OpenTelemetryUtil.fromHookContext(
+            context,
+            providerName: providerName,
+          );
 
     capturedAttributes.add(otelAttributes.toJson());
   }
@@ -125,6 +224,168 @@ void main() {
       }, hints: hints);
 
       expect(testHook.executionOrder, contains('with_hints'));
+    });
+
+    test('shares hook data across stages when provided', () async {
+      final sharedHookData = HookData();
+
+      await manager.executeHooks(HookStage.BEFORE, 'test-flag', {
+        'user': 'test',
+      }, hookData: sharedHookData);
+
+      await manager.executeHooks(
+        HookStage.AFTER,
+        'test-flag',
+        {'user': 'test'},
+        result: true,
+        hookData: sharedHookData,
+      );
+
+      expect(
+        identical(testHook.beforeHookData, testHook.afterHookData),
+        isTrue,
+      );
+      expect(testHook.afterHookData?.get('fromBefore'), isTrue);
+    });
+
+    test('runs after, error, and finally hooks in reverse order', () async {
+      final calls = <String>[];
+      final first = NamedHook('first', calls, HookPriority.HIGH);
+      final second = NamedHook('second', calls, HookPriority.LOW);
+      manager
+        ..addHook(first)
+        ..addHook(second);
+
+      await manager.executeHooks(
+        HookStage.AFTER,
+        'test-flag',
+        {},
+        result: true,
+      );
+      await manager.executeHooks(
+        HookStage.ERROR,
+        'test-flag',
+        {},
+        error: Exception('boom'),
+      );
+      await manager.executeHooks(HookStage.FINALLY, 'test-flag', {});
+
+      expect(
+        calls,
+        equals([
+          'after:second',
+          'after:first',
+          'error:second',
+          'error:first',
+          'finally:second',
+          'finally:first',
+        ]),
+      );
+    });
+
+    test('before hooks can contribute merged evaluation context', () async {
+      final mergingHook = TestHook(HookPriority.NORMAL, {
+        'hook': 'value',
+        'user': 'hook-user',
+      });
+      manager.addHook(mergingHook);
+
+      final mergedContext = await manager.executeHooks(
+        HookStage.BEFORE,
+        'test-flag',
+        {'user': 'invocation-user', 'region': 'us'},
+      );
+
+      expect(mergedContext['region'], equals('us'));
+      expect(mergedContext['hook'], equals('value'));
+      expect(mergedContext['user'], equals('hook-user'));
+    });
+
+    test('before and after failures stop the rest of that stage', () async {
+      final calls = <String>[];
+      manager
+        ..addHook(
+          ThrowingHook(
+            calls: calls,
+            stageToThrow: 'before',
+            name: 'first',
+            priority: HookPriority.HIGH,
+          ),
+        )
+        ..addHook(NamedHook('second', calls, HookPriority.LOW));
+
+      expect(
+        () => manager.executeHooks(HookStage.BEFORE, 'test-flag', {}),
+        throwsException,
+      );
+      expect(calls, equals(['before:first']));
+    });
+
+    test('error and finally failures do not stop remaining hooks', () async {
+      final calls = <String>[];
+      manager
+        ..addHook(
+          ThrowingHook(
+            calls: calls,
+            stageToThrow: 'error',
+            name: 'first',
+            priority: HookPriority.HIGH,
+          ),
+        )
+        ..addHook(NamedHook('second', calls, HookPriority.LOW));
+
+      await manager.executeHooks(
+        HookStage.ERROR,
+        'test-flag',
+        {},
+        error: Exception('boom'),
+      );
+
+      expect(calls, equals(['error:second', 'error:first']));
+
+      calls.clear();
+      final finallyManager = HookManager()
+        ..addHook(
+          ThrowingHook(
+            calls: calls,
+            stageToThrow: 'finally',
+            name: 'first',
+            priority: HookPriority.HIGH,
+          ),
+        )
+        ..addHook(NamedHook('second', calls, HookPriority.LOW));
+
+      await finallyManager.executeHooks(HookStage.FINALLY, 'test-flag', {});
+      expect(calls, equals(['finally:second', 'finally:first']));
+    });
+
+    test('hook data is isolated per hook instance', () async {
+      final first = TestHook(HookPriority.HIGH, {'hookId': 'first'});
+      final second = TestHook(HookPriority.LOW, {'hookId': 'second'});
+      manager
+        ..addHook(first)
+        ..addHook(second);
+
+      final sharedHookData = HookData();
+      final mergedContext = await manager.executeHooks(
+        HookStage.BEFORE,
+        'test-flag',
+        {'user': 'test'},
+        hookData: sharedHookData,
+      );
+
+      await manager.executeHooks(
+        HookStage.AFTER,
+        'test-flag',
+        mergedContext,
+        result: true,
+        hookData: sharedHookData,
+      );
+
+      expect(identical(first.beforeHookData, second.beforeHookData), isFalse);
+      expect(identical(first.afterHookData, second.afterHookData), isFalse);
+      expect(identical(first.beforeHookData, first.afterHookData), isTrue);
+      expect(identical(second.beforeHookData, second.afterHookData), isTrue);
     });
   });
 
@@ -285,6 +546,67 @@ void main() {
         otelHook.capturedAttributes[0][OTelFeatureFlagConstants.REASON],
         equals(OTelFeatureFlagConstants.REASON_ERROR),
       );
+    });
+  });
+
+  group('LoggingHook', () {
+    test('serializes non-JSON values safely', () async {
+      final messages = <String>[];
+      final hook = LoggingHook(logger: messages.add, includeContext: true);
+
+      await hook.before(
+        HookContext(
+          flagKey: 'test-flag',
+          evaluationContext: {
+            'when': DateTime.utc(2026, 4, 20),
+            'duration': const Duration(seconds: 5),
+            'setLike': {1, 2, 3},
+          },
+          result: Object(),
+        ),
+      );
+
+      expect(messages, hasLength(1));
+      expect(messages.single, contains('"flagKey":"test-flag"'));
+      expect(messages.single, contains('"duration":5000000'));
+      expect(messages.single, contains('"setLike":[1,2,3]'));
+    });
+
+    test('serializes circular structures without throwing', () async {
+      final messages = <String>[];
+      final hook = LoggingHook(logger: messages.add, includeContext: true);
+      final circular = <String, dynamic>{};
+      circular['self'] = circular;
+
+      await hook.before(
+        HookContext(
+          flagKey: 'test-flag',
+          evaluationContext: circular,
+          result: circular,
+        ),
+      );
+
+      expect(messages, hasLength(1));
+      expect(messages.single, contains(r'"self":"[Circular]"'));
+    });
+
+    test('falls back to an error message when serialization fails', () async {
+      final messages = <String>[];
+      final hook = LoggingHook(logger: messages.add, includeContext: true);
+
+      await hook.before(
+        HookContext(
+          flagKey: 'test-flag',
+          evaluationContext: {'broken': BrokenStringify()},
+        ),
+      );
+
+      expect(messages, hasLength(1));
+      expect(
+        messages.single,
+        contains('LoggingHook failed to serialize log for stage: before'),
+      );
+      expect(messages.single, contains('flag: test-flag'));
     });
   });
 }

--- a/test/multi_provider_test.dart
+++ b/test/multi_provider_test.dart
@@ -1,0 +1,246 @@
+import 'package:test/test.dart';
+
+import '../lib/feature_provider.dart';
+import '../lib/multi_provider.dart';
+
+class _StubProvider implements FeatureProvider {
+  _StubProvider({
+    required this.providerName,
+    this.booleanFlags = const {},
+    this.shouldFailInitialization = false,
+    this.shouldFailTracking = false,
+  });
+
+  final String providerName;
+  final Map<String, bool> booleanFlags;
+  final bool shouldFailInitialization;
+  final bool shouldFailTracking;
+  ProviderState _state = ProviderState.NOT_READY;
+  int trackingCalls = 0;
+
+  @override
+  String get name => providerName;
+
+  @override
+  ProviderState get state => _state;
+
+  @override
+  ProviderConfig get config => const ProviderConfig();
+
+  @override
+  ProviderMetadata get metadata => ProviderMetadata(name: providerName);
+
+  @override
+  Future<void> initialize([Map<String, dynamic>? config]) async {
+    if (shouldFailInitialization) {
+      _state = ProviderState.ERROR;
+      throw ProviderException(
+        'Initialization failed for $providerName',
+        code: ErrorCode.PROVIDER_NOT_READY,
+      );
+    }
+    _state = ProviderState.READY;
+  }
+
+  @override
+  Future<void> connect() async {
+    _state = ProviderState.READY;
+  }
+
+  @override
+  Future<void> shutdown() async {
+    _state = ProviderState.SHUTDOWN;
+  }
+
+  @override
+  Future<void> track(
+    String trackingEventName, {
+    Map<String, dynamic>? evaluationContext,
+    TrackingEventDetails? trackingDetails,
+  }) async {
+    if (shouldFailTracking) {
+      throw ProviderException(
+        'Tracking failed for $providerName',
+        code: ErrorCode.GENERAL,
+      );
+    }
+    trackingCalls++;
+  }
+
+  @override
+  Future<FlagEvaluationResult<bool>> getBooleanFlag(
+    String flagKey,
+    bool defaultValue, {
+    Map<String, dynamic>? context,
+  }) async {
+    if (_state != ProviderState.READY) {
+      return FlagEvaluationResult.error(
+        flagKey,
+        defaultValue,
+        ErrorCode.PROVIDER_NOT_READY,
+        'Provider $providerName not ready.',
+        evaluatorId: providerName,
+      );
+    }
+
+    if (!booleanFlags.containsKey(flagKey)) {
+      return FlagEvaluationResult.error(
+        flagKey,
+        defaultValue,
+        ErrorCode.FLAG_NOT_FOUND,
+        'Flag "$flagKey" not found in $providerName.',
+        evaluatorId: providerName,
+      );
+    }
+
+    return FlagEvaluationResult(
+      flagKey: flagKey,
+      value: booleanFlags[flagKey]!,
+      reason: 'STATIC',
+      evaluatedAt: DateTime.now(),
+      evaluatorId: providerName,
+    );
+  }
+
+  @override
+  Future<FlagEvaluationResult<String>> getStringFlag(
+    String flagKey,
+    String defaultValue, {
+    Map<String, dynamic>? context,
+  }) async => throw UnimplementedError();
+
+  @override
+  Future<FlagEvaluationResult<int>> getIntegerFlag(
+    String flagKey,
+    int defaultValue, {
+    Map<String, dynamic>? context,
+  }) async => throw UnimplementedError();
+
+  @override
+  Future<FlagEvaluationResult<double>> getDoubleFlag(
+    String flagKey,
+    double defaultValue, {
+    Map<String, dynamic>? context,
+  }) async => throw UnimplementedError();
+
+  @override
+  Future<FlagEvaluationResult<Map<String, dynamic>>> getObjectFlag(
+    String flagKey,
+    Map<String, dynamic> defaultValue, {
+    Map<String, dynamic>? context,
+  }) async => throw UnimplementedError();
+}
+
+void main() {
+  group('MultiProvider', () {
+    test('returns the first successful result', () async {
+      final primary = _StubProvider(
+        providerName: 'PrimaryProvider',
+        booleanFlags: {'feature-a': true},
+      );
+      final fallback = _StubProvider(
+        providerName: 'FallbackProvider',
+        booleanFlags: {'feature-a': false},
+      );
+
+      final multiProvider = MultiProvider([primary, fallback]);
+      await multiProvider.initialize();
+
+      final result = await multiProvider.getBooleanFlag('feature-a', false);
+
+      expect(result.value, isTrue);
+      expect(result.evaluatorId, equals('PrimaryProvider'));
+    });
+
+    test('falls back when a provider returns FLAG_NOT_FOUND', () async {
+      final primary = _StubProvider(providerName: 'PrimaryProvider');
+      final fallback = _StubProvider(
+        providerName: 'FallbackProvider',
+        booleanFlags: {'feature-a': true},
+      );
+
+      final multiProvider = MultiProvider([primary, fallback]);
+      await multiProvider.initialize();
+
+      final result = await multiProvider.getBooleanFlag('feature-a', false);
+
+      expect(result.value, isTrue);
+      expect(result.evaluatorId, equals('FallbackProvider'));
+    });
+
+    test(
+      'returns the first non-FLAG_NOT_FOUND error if no provider succeeds',
+      () async {
+        final broken = _StubProvider(
+          providerName: 'BrokenProvider',
+          booleanFlags: const {},
+        );
+        final missing = _StubProvider(providerName: 'MissingProvider');
+
+        final multiProvider = MultiProvider([broken, missing]);
+        await broken.initialize();
+        await missing.initialize();
+        await broken.shutdown();
+
+        final result = await multiProvider.getBooleanFlag('feature-a', false);
+
+        expect(result.value, isFalse);
+        expect(result.errorCode, equals(ErrorCode.PROVIDER_NOT_READY));
+        expect(result.evaluatorId, equals('BrokenProvider'));
+      },
+    );
+
+    test(
+      'initialization succeeds when at least one provider becomes ready',
+      () async {
+        final broken = _StubProvider(
+          providerName: 'BrokenProvider',
+          shouldFailInitialization: true,
+        );
+        final healthy = _StubProvider(
+          providerName: 'HealthyProvider',
+          booleanFlags: {'feature-a': true},
+        );
+
+        final multiProvider = MultiProvider([broken, healthy]);
+        await multiProvider.initialize();
+
+        expect(multiProvider.state, equals(ProviderState.ERROR));
+        final result = await multiProvider.getBooleanFlag('feature-a', false);
+        expect(result.value, isTrue);
+        expect(result.evaluatorId, equals('HealthyProvider'));
+      },
+    );
+
+    test('fans out tracking calls to every provider', () async {
+      final primary = _StubProvider(providerName: 'PrimaryProvider');
+      final fallback = _StubProvider(providerName: 'FallbackProvider');
+
+      final multiProvider = MultiProvider([primary, fallback]);
+      await primary.initialize();
+      await fallback.initialize();
+
+      await multiProvider.track('checkout-completed');
+
+      expect(primary.trackingCalls, equals(1));
+      expect(fallback.trackingCalls, equals(1));
+    });
+
+    test('tracking is best-effort when one provider fails', () async {
+      final primary = _StubProvider(
+        providerName: 'PrimaryProvider',
+        shouldFailTracking: true,
+      );
+      final fallback = _StubProvider(providerName: 'FallbackProvider');
+
+      final multiProvider = MultiProvider([primary, fallback]);
+      await primary.initialize();
+      await fallback.initialize();
+
+      await multiProvider.track('checkout-completed');
+
+      expect(primary.trackingCalls, equals(0));
+      expect(fallback.trackingCalls, equals(1));
+    });
+  });
+}

--- a/test/open_feature_api_test.dart
+++ b/test/open_feature_api_test.dart
@@ -5,17 +5,21 @@ import '../lib/open_feature_event.dart';
 
 class TestProvider implements FeatureProvider {
   final Map<String, dynamic> _flags;
+  final String _providerName;
   ProviderState _state;
   final bool _shouldFailInitialization;
 
   TestProvider(
-    this._flags, [
-    this._state = ProviderState.NOT_READY,
-    this._shouldFailInitialization = false,
-  ]);
+    this._flags, {
+    String providerName = 'TestProvider',
+    ProviderState state = ProviderState.NOT_READY,
+    bool shouldFailInitialization = false,
+  }) : _providerName = providerName,
+       _state = state,
+       _shouldFailInitialization = shouldFailInitialization;
 
   @override
-  String get name => 'TestProvider';
+  String get name => _providerName;
 
   @override
   ProviderState get state => _state;
@@ -24,13 +28,16 @@ class TestProvider implements FeatureProvider {
   ProviderConfig get config => ProviderConfig();
 
   @override
-  ProviderMetadata get metadata => ProviderMetadata(name: 'TestProvider');
+  ProviderMetadata get metadata => ProviderMetadata(name: _providerName);
 
   @override
   Future<void> initialize([Map<String, dynamic>? config]) async {
     if (_shouldFailInitialization) {
       _state = ProviderState.ERROR;
-      throw Exception('Initialization failed');
+      throw const ProviderException(
+        'Initialization failed',
+        code: ErrorCode.PROVIDER_NOT_READY,
+      );
     }
     _state = ProviderState.READY;
   }
@@ -210,8 +217,8 @@ void main() {
       final api = OpenFeatureAPI();
       final provider = TestProvider(
         {'test-flag': true},
-        ProviderState.NOT_READY,
-        true,
+        state: ProviderState.NOT_READY,
+        shouldFailInitialization: true,
       );
 
       await api.setProvider(provider);
@@ -226,6 +233,28 @@ void main() {
     test('binds client to provider', () {
       final api = OpenFeatureAPI();
       api.bindClientToProvider('client1', 'provider1');
+    });
+
+    test('routes domain-bound clients to registered providers', () async {
+      final api = OpenFeatureAPI();
+      final defaultProvider = TestProvider(
+        {'test': true},
+        providerName: 'default-provider',
+      );
+      final secondaryProvider = TestProvider(
+        {'test': false},
+        providerName: 'secondary-provider',
+      );
+
+      await api.setProvider(defaultProvider);
+      api.registerProvider(secondaryProvider);
+      api.bindClientToProvider('checkout', secondaryProvider.metadata.name);
+
+      final client = api.getClient('checkout', domain: 'checkout');
+      expect(
+        client.provider.metadata.name,
+        equals(secondaryProvider.metadata.name),
+      );
     });
 
     test('emits events on provider change', () async {
@@ -246,7 +275,11 @@ void main() {
 
     test('emits error events for flag evaluation issues', () async {
       final api = OpenFeatureAPI();
-      final provider = TestProvider({}, ProviderState.NOT_READY, true);
+      final provider = TestProvider(
+        {},
+        state: ProviderState.NOT_READY,
+        shouldFailInitialization: true,
+      );
       final events = <OpenFeatureEvent>[];
 
       api.events.listen(events.add);
@@ -258,6 +291,27 @@ void main() {
         events.any((e) => e.type == OpenFeatureEventType.PROVIDER_ERROR),
         isTrue,
       );
+      expect(
+        events.any(
+          (e) =>
+              e.type == OpenFeatureEventType.PROVIDER_ERROR &&
+              e.errorCode == ErrorCode.PROVIDER_NOT_READY,
+        ),
+        isTrue,
+      );
+    });
+
+    test('supports explicit API event handlers', () async {
+      final api = OpenFeatureAPI();
+      final provider = TestProvider({'test': true});
+      final events = <OpenFeatureEvent>[];
+
+      final sub = api.addHandler(events.add);
+      await api.setProvider(provider);
+      await Future.delayed(Duration(milliseconds: 10));
+
+      expect(events, isNotEmpty);
+      await api.removeHandler(sub);
     });
 
     test('handles evaluation errors gracefully', () async {

--- a/test/open_feature_event_test.dart
+++ b/test/open_feature_event_test.dart
@@ -1,5 +1,5 @@
-import 'package:openfeature_dart_server_sdk/feature_provider.dart';
 import 'package:test/test.dart';
+import '../lib/feature_provider.dart';
 import '../lib/open_feature_event.dart';
 
 void main() {

--- a/test/transaction_context_test.dart
+++ b/test/transaction_context_test.dart
@@ -81,6 +81,24 @@ void main() {
       expect(manager.currentContext, isNull);
     });
 
+    test('isolates async contexts across overlapping operations', () async {
+      final seen = <String>[];
+
+      await Future.wait([
+        manager.withContext('tx-a', {'requestId': 'a'}, () async {
+          await Future.delayed(const Duration(milliseconds: 20));
+          seen.add(manager.currentContext?.attributes['requestId'] as String);
+        }),
+        manager.withContext('tx-b', {'requestId': 'b'}, () async {
+          await Future.delayed(const Duration(milliseconds: 5));
+          seen.add(manager.currentContext?.attributes['requestId'] as String);
+        }),
+      ]);
+
+      expect(seen.toSet(), equals({'a', 'b'}));
+      expect(manager.currentContext, isNull);
+    });
+
     test('creates child context', () {
       final parent = TransactionContext(
         transactionId: 'parent',


### PR DESCRIPTION
## This PR
Multi-Provider (Experimental)

New MultiProvider class enabling composition of multiple providers
FirstMatchStrategy for fallback provider logic with first-match semantics
Comprehensive test coverage for multi-provider scenarios (246 tests)
Providers evaluated in order; FLAG_NOT_FOUND treated as miss, continuing to next provider
Hook Lifecycle & Event Handling

Aligned hook execution with OpenFeature specification
Enhanced hook manager with improved error handling and isolation
Hook data is now isolated per hook instance
Error and finally hook failures no longer stop remaining hooks from executing
Added 165+ new hook-related tests
Documentation Enhancements

Reformatted and clarified all feature descriptions in README
Updated feature status table (Implemented/Experimental/Not implemented)
Improved code examples with consistent formatting and modern syntax
Enhanced sections for Tracking, Logging, Domains, Eventing, Multi-Provider
Removed redundant comments and simplified headers
Updated Dart version requirement to 3.11.4
Core Library Improvements

Enhanced client implementation with better context merging (lib/client.dart)
Improved evaluation context handling
Transaction context refinements with better async isolation
Event system updates for proper event forwarding
API improvements for provider and domain management