### PR TITLE
fix: remove duplicate release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,6 @@
   <!-- x-release-please-start-version -->
   <a href="https://github.com/open-feature/dart-server-sdk/releases/tag/v0.0.20">
     <img alt="Release" src="https://img.shields.io/static/v1?label=release&message=v0.0.20&color=blue&style=for-the-badge" />
-
-
-  <a href="https://github.com/open-feature/dart-server-sdk/releases/tag/v0.0.20">
-    <img alt="Release" src="https://img.shields.io/static/v1?label=release&message=v0.0.20&color=blue&style=for-the-badge" />
-
   </a>
   <!-- x-release-please-end -->
   <a href="https://dart.dev/">


### PR DESCRIPTION
Removed duplicate release badge from README.
This is breaking https://github.com/open-feature/openfeature.dev/pull/1370 due to the missing `</a>`.