### PR TITLE
fix: run parent pipeline without pull_request_target

### DIFF
--- a/.github/workflows/parent-pipeline.yml
+++ b/.github/workflows/parent-pipeline.yml
@@ -7,7 +7,7 @@ on:
     branches-ignore:
       - test
 
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -25,9 +25,9 @@ jobs:
         name: Extract Branch and Event
         run: |
           echo "Extracting branch and event context..."
-          echo "Branch Name: ${{ github.ref_name }}"
+          echo "Branch Name: ${{ github.head_ref || github.ref_name }}"
           echo "Event Name: ${{ github.event_name }}"
-          echo "branch_name=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          echo "branch_name=${{ github.head_ref || github.ref_name }}" >> $GITHUB_OUTPUT
           echo "event_name=${{ github.event_name }}" >> $GITHUB_OUTPUT
   trigger-validation:
     name: Trigger Validation Workflow

--- a/.github/workflows/parent-pipeline.yml
+++ b/.github/workflows/parent-pipeline.yml
@@ -13,6 +13,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   determine-workflow:
     name: Determine Workflow Context
@@ -23,12 +26,15 @@ jobs:
     steps:
       - id: determine
         name: Extract Branch and Event
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           echo "Extracting branch and event context..."
-          echo "Branch Name: ${{ github.head_ref || github.ref_name }}"
-          echo "Event Name: ${{ github.event_name }}"
-          echo "branch_name=${{ github.head_ref || github.ref_name }}" >> $GITHUB_OUTPUT
-          echo "event_name=${{ github.event_name }}" >> $GITHUB_OUTPUT
+          echo "Branch Name: $BRANCH_NAME"
+          echo "Event Name: $EVENT_NAME"
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+          echo "event_name=$EVENT_NAME" >> "$GITHUB_OUTPUT"
   trigger-validation:
     name: Trigger Validation Workflow
     needs: determine-workflow


### PR DESCRIPTION
## Summary

- Change the parent pipeline PR trigger from `pull_request_target` to `pull_request`
- Preserve branch-name validation for PRs by using `github.head_ref` before falling back to `github.ref_name`

## Motivation

The parent pipeline invokes reusable workflows that check out code and run Dart commands. Running that path under `pull_request_target` means untrusted PR code can execute in the base repository context, which creates a Pwn Request-style trust boundary issue.

Using `pull_request` keeps PR validation behavior while avoiding privileged execution for contributor code.