### PR TITLE
fix(release): publish each version once

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,7 +11,7 @@ jobs:
       id-token: write # Required for authentication using OIDC
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: dart-lang/setup-dart@v1
       - name: Install dependencies
         run: dart pub get

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,21 +33,5 @@ jobs:
       release_tag_name: ${{ steps.release.outputs.tag_name }}
       upload_url: ${{ steps.release.outputs.upload_url }}
 
-# Publishing is handled in publish.yaml
-  dart-release:
-    needs: release-please
-    if: ${{ fromJSON(needs.release-please.outputs.release_created || false) }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write # Required for authentication using OIDC
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - uses: dart-lang/setup-dart@v1
-      - name: Install dependencies
-        run: dart pub get
-      - name: Publish
-        run: dart pub publish --force
-
-# Publishing is handled in publish.yaml
+# Package publication is handled exclusively by publish.yaml when
+# release-please creates a version tag.


### PR DESCRIPTION
## Summary

- remove the duplicate pub.dev publishing job from release.yaml;
- keep publish.yaml as the single tag-triggered publisher;
- update the remaining publishing workflow from actions/checkout v3 to the current supported v7 major.

## Why

Run Release #64 created release tag v0.0.22 and then attempted to publish directly. The tag simultaneously triggered Publish to pub.dev, which published 0.0.22 successfully. The duplicate direct publish then failed because pub.dev versions are immutable.

Failed duplicate run: https://github.com/open-feature/dart-server-sdk/actions/runs/25758462871

## Validation

- actionlint 1.7.12
- git diff --check
- confirmed release.yaml contains no dart pub publish command
- confirmed publish.yaml contains the sole dart pub publish command

No GitHub issue applies; this PR addresses the existing release-run failure directly.