### PR TITLE
chore(ci): validate Dart 3.12.2 SDK

### DIFF
--- a/.github/workflows/contributor-workflow.yml
+++ b/.github/workflows/contributor-workflow.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1
@@ -57,26 +57,19 @@ jobs:
           echo "Checking for outdated dependencies..."
           dart pub outdated || true
 
-      # - name: Run Static Analysis (capture & show)
-      #   id: analyze
-      #   working-directory: ${{ steps.pkg.outputs.dir }}
-      #   shell: bash
-      #   run: |
-      #     set -o pipefail
-      #     echo "Running static analysis for core SDK..."
-      #     # Write both stdout and stderr to files while also echoing to the log.
-      #     # Keep stdout and stderr separate so we can categorize later.
-      #     # stdout -> analysis_report.txt, stderr -> error_log.txt
-      #     { dart analyze lib/ | tee analysis_report.txt; } 2> >(tee error_log.txt >&2)
-      #     STATUS=${PIPESTATUS[0]}
-      #     if [[ $STATUS -ne 0 ]]; then
-      #       echo "❌ Static analysis failed. See error_log.txt below:"
-      #       sed -n '1,200p' error_log.txt || true
-      #     else
-      #       echo "✅ Static analysis completed successfully. No critical errors found."
-      #     fi
-      #     echo "status=$STATUS" >> "$GITHUB_OUTPUT"
-      #     exit $STATUS || true  # Don’t fail the step here; allow categorization + artifacts.
+      - name: Run Static Analysis (capture and show)
+        id: analyze
+        working-directory: ${{ steps.pkg.outputs.dir }}
+        shell: bash
+        run: |
+          set -o pipefail
+          echo "Running static analysis for core SDK..."
+          set +e
+          { dart analyze lib/ | tee analysis_report.txt; } 2> >(tee error_log.txt >&2)
+          STATUS=${PIPESTATUS[0]}
+          set -e
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          exit 0
 
       - name: Categorize and Count Analysis Results
         if: always()
@@ -150,7 +143,7 @@ jobs:
 
       # Fail the job if the analyzer actually failed.
       - name: Fail if analyzer failed
-        if: ${{ steps.analyze.outputs.status != '0' }}
+        if: ${{ always() && steps.analyze.outputs.status != '0' }}
         run: |
-          echo "❌ Failing job because the analyzer returned a non-zero exit code."
+          echo "Failing job because the analyzer returned a non-zero exit code."
           exit 1

--- a/.github/workflows/coverage-workflow.yml
+++ b/.github/workflows/coverage-workflow.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Dart
         uses: dart-lang/setup-dart@v1
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download coverage artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -16,16 +16,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [3.1, stable, beta]
+        sdk: [3.12.2, stable, beta]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: ${{ matrix.sdk }}
-      
-      # TODO: Uncomment once there's something to test!
-      # - name: Install dependencies
-      #  run: dart pub get
 
-      # - name: Run tests
-      #   run: dart test
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Analyze
+        run: dart analyze
+
+      - name: Run tests
+        run: dart test

--- a/.github/workflows/validation-workflow.yml
+++ b/.github/workflows/validation-workflow.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Validate Dart SDK versions in all pubspec.yaml files
         run: |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ favorite feature flag management tool.
 
 ### Requirements
 
-Dart language version: [3.11.4](https://dart.dev/get-dart/archive)
+Dart language version: [3.12.2](https://dart.dev/get-dart/archive)
 
 > [!NOTE]
 > The OpenFeature Dart Server SDK only supports the latest currently maintained

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ version: 0.0.22
 
 homepage: https://github.com/open-feature/dart-server-sdk
 environment:
-  sdk: ^3.11.4
+  sdk: ^3.12.2
 
 dependencies:
   # Core dependencies


### PR DESCRIPTION
## Summary

- require Dart 3.12.2 in the package manifest and documentation
- validate the minimum supported SDK, stable, and beta across Linux, macOS, and Windows
- run dependency resolution, static analysis, and unit tests in the pull-request matrix
- restore the contributor workflow's analyzer step and preserve its report artifacts
- align workflow checkout actions with the repository's current v7 usage

## Why

The previous minimum matrix lane still targeted Dart 3.1, while the package already required Dart 3.11.4. Its install and test steps were also commented out, so the matrix did not exercise the SDK. This change makes the CI signal meaningful and advances the documented minimum to the current Dart 3.12.2 stable toolchain.

Release Please remains responsible for package version and changelog changes; this PR deliberately does not change version `0.0.22`.

## Validation

- `actionlint` 1.7.12 across all 10 workflows
- `dart pub get`
- `dart analyze` (no issues)
- `dart test` (133 tests passed)
- `dart pub publish --dry-run` (0 warnings; no publication performed)

## Linked issue

No issue applies; this is isolated SDK toolchain and CI maintenance ahead of the client and server conformance work.