### PR TITLE
fix(ci): dedupe GitHub validation

### DIFF
--- a/.github/workflows/contributor-workflow.yml
+++ b/.github/workflows/contributor-workflow.yml
@@ -4,18 +4,12 @@ name: Contributor Workflow
 
 on:
   workflow_call: # Makes the workflow reusable
-    inputs:
-      branch_name:
-        required: true
-        type: string
-      event_name:
-        required: true
-        type: string
 
 jobs:
   analyze-core:
     name: Analyze Core Dart Server SDK
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/contributor-workflow.yml
+++ b/.github/workflows/contributor-workflow.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Upload Analysis Artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: core-sdk-analysis
           path: |

--- a/.github/workflows/coverage-workflow.yml
+++ b/.github/workflows/coverage-workflow.yml
@@ -62,7 +62,7 @@ jobs:
         run: ls -al coverage
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV__UPLOAD_TOKEN }} # omit for public repos if you want
           slug: open-feature/dart-server-sdk

--- a/.github/workflows/coverage-workflow.yml
+++ b/.github/workflows/coverage-workflow.yml
@@ -2,17 +2,11 @@ name: Coverage Workflow
 
 on:
   workflow_call:
-    inputs:
-      branch_name:
-        required: true
-        type: string
-      event_name:
-        required: true
-        type: string
 
 jobs:
   test-and-upload:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -31,12 +25,9 @@ jobs:
           mkdir -p coverage
           dart test --coverage=coverage
 
-      - name: Activate coverage package
-        run: dart pub global activate coverage
-
       - name: Generate LCOV report
         run: |
-          dart pub global run coverage:format_coverage \
+          dart run coverage:format_coverage \
             --in=coverage \
             --out=coverage/lcov.info \
             --lcov \
@@ -55,6 +46,7 @@ jobs:
   upload-coverage:
     runs-on: ubuntu-latest
     needs: test-and-upload
+    timeout-minutes: 5
 
     steps:
       - name: Checkout code

--- a/.github/workflows/coverage-workflow.yml
+++ b/.github/workflows/coverage-workflow.yml
@@ -38,7 +38,7 @@ jobs:
         run: ls -al coverage
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage/lcov.info
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: coverage-report
           path: coverage

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -17,6 +21,7 @@ jobs:
       statuses: write  # for amannn/action-semantic-pull-request to mark status of analyzed PR
     name: Validate PR title
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         id: lint_pr_title

--- a/.github/workflows/parent-pipeline.yml
+++ b/.github/workflows/parent-pipeline.yml
@@ -4,57 +4,39 @@ name: Parent Pipeline
 
 on:
   push:
-    branches-ignore:
-      - test
+    branches:
+      - main
+      - qa
+      - development
 
   pull_request:
     types:
       - opened
-      - edited
+      - reopened
       - synchronize
+      - ready_for_review
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
-  determine-workflow:
-    name: Determine Workflow Context
-    runs-on: ubuntu-latest
-    outputs:
-      branch_name: ${{ steps.determine.outputs.branch_name }}
-      event_name: ${{ steps.determine.outputs.event_name }}
-    steps:
-      - id: determine
-        name: Extract Branch and Event
-        env:
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          echo "Extracting branch and event context..."
-          echo "Branch Name: $BRANCH_NAME"
-          echo "Event Name: $EVENT_NAME"
-          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
-          echo "event_name=$EVENT_NAME" >> "$GITHUB_OUTPUT"
   trigger-validation:
     name: Trigger Validation Workflow
-    needs: determine-workflow
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     uses: ./.github/workflows/validation-workflow.yml
     with:
-      branch_name: ${{ needs.determine-workflow.outputs.branch_name }}
-      event_name: ${{ needs.determine-workflow.outputs.event_name }}
+      branch_name: ${{ github.head_ref || github.ref_name }}
 
   trigger-coverage:
     name: Trigger Coverage Workflow
-    needs: determine-workflow
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     uses: ./.github/workflows/coverage-workflow.yml
-    with:
-      branch_name: ${{ needs.determine-workflow.outputs.branch_name }}
-      event_name: ${{ needs.determine-workflow.outputs.event_name }}
 
   contributor-workflow:
     name: Trigger Contributor Workflow
-    needs: determine-workflow
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     uses: ./.github/workflows/contributor-workflow.yml
-    with:
-      branch_name: ${{ needs.determine-workflow.outputs.branch_name }}
-      event_name: ${{ needs.determine-workflow.outputs.event_name }}

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -4,7 +4,16 @@ on:
     branches:
       - main
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -12,8 +21,11 @@ permissions:
 jobs:
   test:
     name: test
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         sdk: [3.12.2, stable, beta]

--- a/.github/workflows/validation-workflow.yml
+++ b/.github/workflows/validation-workflow.yml
@@ -8,9 +8,6 @@ on:
       branch_name:
         required: true
         type: string
-      event_name:
-        required: true
-        type: string
 
 jobs:
   validate-branch-name:
@@ -26,11 +23,11 @@ jobs:
 
           if [[ "$BRANCH_NAME" =~ ^(qa|development|main|release-please--branches--main--components--openfeature_dart_server_sdk)$ ]]; then
             echo "✅ Branch name '$BRANCH_NAME' is valid for protected branches (qa, development, main)."
-          elif [[ "$BRANCH_NAME" =~ ^(feat|fix|hotfix|chore|test|refactor|release)/[a-z0-9._-]+$ ]]; then
+          elif [[ "$BRANCH_NAME" =~ ^(feat|fix|hotfix|chore|test|refactor|release|admin|docs|ci)/[a-z0-9._-]+$ ]]; then
             echo "✅ Branch name '$BRANCH_NAME' follows the naming convention."
           else
             echo "❌ Branch name '$BRANCH_NAME' does not follow the naming convention: <type>/<branch-name>"
-            echo "Valid types: feat, fix, hotfix, chore, test, refactor, release, qa, main, development"
+            echo "Valid types: feat, fix, hotfix, chore, test, refactor, release, admin, docs, ci, qa, main, development"
             exit 1
           fi
 
@@ -49,25 +46,31 @@ jobs:
           echo "Validating commit messages..."
 
           # Define the regex for conventional commit format
-          REGEX="^(feat|fix|hotfix|chore|test|refactor|release|ci)(\([a-z0-9_-]+\))?: .{1,72}$"
+          REGEX="^(feat|fix|hotfix|chore|test|refactor|release|admin|docs|ci)(\([a-z0-9_-]+\))?: .{1,72}$"
 
-          # Fetch the base branch dynamically (fallback to 'main' if not in a pull request)
-          BASE_BRANCH=${{ github.event.pull_request.base.ref || 'main' }}
-          echo "Base branch: $BASE_BRANCH"
-
-          # Fetch all commits between the base branch and the current branch
-          git fetch origin $BASE_BRANCH
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+            git fetch origin "$BASE_BRANCH"
+            COMMIT_RANGE="origin/$BASE_BRANCH..HEAD"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            BEFORE_SHA="${{ github.event.before }}"
+            AFTER_SHA="${{ github.sha }}"
+            if [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
+              COMMIT_RANGE="$AFTER_SHA^..$AFTER_SHA"
+            else
+              COMMIT_RANGE="$BEFORE_SHA..$AFTER_SHA"
+            fi
+          else
+            COMMIT_RANGE="HEAD^..HEAD"
+          fi
+          echo "Commit range: $COMMIT_RANGE"
 
           # Extract all commit messages excluding auto-generated ones
-          INVALID_COMMITS=$(git log --no merges origin/$BASE_BRANCH..HEAD --pretty=format:"%s" \
+          INVALID_COMMITS=$(git log --no-merges "$COMMIT_RANGE" --pretty=format:"%s" \
             | grep -vE "^(Merge pull request|Initial commit)" \
             | grep -vE "^(Merge remote-tracking branch|Merge pull request)" \
             | grep -vE "^(Merge branch|DCO Remediation|Signed-off-by)" \
             | grep -vE "$REGEX" || true)
-
-          # Check for overly long summaries
-          LONG_SUMMARIES=$(git log origin/$BASE_BRANCH..HEAD --pretty=format:"%s" \
-            | awk 'length($0) > 72')
 
           # Check if there are invalid commit messages
           if [[ -n "$INVALID_COMMITS" ]]; then
@@ -100,7 +103,7 @@ jobs:
           echo "$PUBSPEC_FILES"
 
           # Define the minimum required Dart SDK version
-          MINIMUM_VERSION="3.10.7"
+          MINIMUM_VERSION="3.12.2"
           ALL_VALID="true"
 
           # Iterate over each pubspec.yaml file

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,9 @@ for example `chore/dart-sdk-3.12.2`.
 | `chore`         | For maintenance tasks, such as dependency updates or refactoring. Example: `chore/update-dependencies`. |
 | `release`       | For preparing release branches with versioned changes. Example: `release/v1.2.0`.                   |
 | `test`          | For testing-related changes, such as adding or modifying test cases. Example: `test/add-unit-tests`.|
+| `docs`          | For documentation-only changes. Example: `docs/update-installation`.                               |
+| `ci`            | For CI and workflow maintenance. Example: `ci/dedupe-validation`.                                  |
+| `admin`         | For administrative maintenance. Example: `admin/update-policy`.                                   |
 
 ---
 
@@ -107,6 +110,9 @@ for example `chore/dart-sdk-3.12.2`.
 | `chore`           | `chore/upgrade-dependencies`       |
 | `test`            | `test/add-integration-tests`       |
 | `release`         | `release/v1.2.0`                   |
+| `docs`            | `docs/update-installation`         |
+| `ci`              | `ci/dedupe-validation`             |
+| `admin`           | `admin/update-policy`              |
 
 ---
 
@@ -135,6 +141,9 @@ We follow [Conventional Commits](https://www.conventionalcommits.org) to ensure 
 | `test`        | `test`                 | Adds or updates tests. Example: `test(api): add integration tests`.            |
 | `refactor`    | `refactor`             | Code restructuring without functional changes. Example: `refactor(ui): improve layout`. |
 | `release`     | `release`              | Prepares a versioned release. Example: `release: v1.2.0`.                      |
+| `docs`        | `docs`                 | Updates documentation. Example: `docs(api): clarify evaluation context`.      |
+| `ci`          | `ci`                   | Updates CI or automation. Example: `ci: cancel stale validation runs`.         |
+| `admin`       | `admin`                | Administrative maintenance. Example: `admin: update repository policy`.       |
 
 ---
 
@@ -205,7 +214,8 @@ To maintain consistency and ensure stability, we enforce the following **branch 
    - Pull requests trigger workflows for testing and validation.
 
 3. **Validation on Push and Pull Requests**:
-   - Branch name and commit message validations are run on all branches during pushes.
+   - Short-lived branches are validated when a pull request is opened or updated.
+   - `main`, `qa`, and `development` are validated again after merged changes are pushed.
    - Protected branches also enforce workflow checks and reviews.
 
 ---
@@ -319,7 +329,7 @@ To certify your contribution, you must add a `Signed-off-by` line to your commit
 
 6. **Open a Pull Request**:
    - Navigate to the repository on GitHub.
-   - Open a pull request targeting the `qa` branch.
+   - Open a pull request targeting the `development` branch.
    - Provide a clear title and description summarizing your changes, including:
      - The problem your changes solve.
      - The approach you used.


### PR DESCRIPTION
## Summary

- run the reusable parent pipeline once per pull request instead of again for every feature-branch push
- cancel superseded workflow runs and skip expensive matrices while a pull request is draft
- remove unused context jobs and workflow inputs
- align branch, commit, and minimum Dart SDK validation with repository policy
- use the pinned coverage dependency and current Node.js 24 artifact/Codecov actions
- document the actual development-targeting workflow

## Why

PR #123 created duplicate reusable Ubuntu jobs from its push and pull_request parent runs. With limited hosted runner capacity, the duplicate jobs remained queued and made the pull request appear unstable even though no checks had failed.

The first #125 run confirmed the deduplication, then exposed Node.js 20 deprecation annotations from older artifact and Codecov actions. This pull request upgrades those actions as well.

## Validation

- actionlint 1.7.12
- branch and commit rule cases
- dart analyze
- dart test (133 tests)
- coverage collection and LCOV generation via the pinned package
- dart pub publish --dry-run (0 warnings)
- first GitHub run: one parent workflow only; parent workflow and 9-job Dart matrix passed
- artifact v7/v8 execution passed on the second GitHub run

No issue applies.