### PR TITLE
fix(server): enforce evaluation safety

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -50,6 +50,7 @@ class FeatureClient {
   final HookManager _hookManager;
   final EvaluationContext _defaultContext;
   final EvaluationContext _apiContext;
+  final EvaluationContext Function()? _apiContextResolver;
   final FeatureProvider _fallbackProvider;
   final FeatureProvider Function()? _providerResolver;
   final ProviderState Function(FeatureProvider)? _providerStatusResolver;
@@ -64,6 +65,7 @@ class FeatureClient {
     required HookManager hookManager,
     required EvaluationContext defaultContext,
     EvaluationContext? apiContext,
+    EvaluationContext Function()? apiContextResolver,
     FeatureProvider? provider,
     FeatureProvider Function()? providerResolver,
     ProviderState Function(FeatureProvider)? providerStatusResolver,
@@ -72,6 +74,7 @@ class FeatureClient {
   }) : _hookManager = hookManager,
        _defaultContext = defaultContext,
        _apiContext = apiContext ?? const EvaluationContext(attributes: {}),
+       _apiContextResolver = apiContextResolver,
        _fallbackProvider = provider ?? InMemoryProvider({}),
        _providerResolver = providerResolver,
        _providerStatusResolver = providerStatusResolver,
@@ -125,13 +128,34 @@ class FeatureClient {
     _hookManager.removeHook(hook);
   }
 
-  Map<String, dynamic> _buildEffectiveContext(Map<String, dynamic>? context) {
+  Map<String, dynamic> _buildEffectiveContext(EvaluationContext? context) {
+    final apiContext = _apiContextResolver?.call() ?? _apiContext;
     return {
-      ..._apiContext.attributes,
+      ...apiContext.toProviderContext(),
       ..._transactionManager.currentContext?.effectiveAttributes ?? {},
-      ..._defaultContext.attributes,
-      ...context ?? {},
+      ..._defaultContext.toProviderContext(),
+      ...context?.toProviderContext() ?? {},
     };
+  }
+
+  void _ensureProviderCanEvaluate(FeatureProvider evaluationProvider) {
+    final state =
+        _providerStatusResolver?.call(evaluationProvider) ??
+        evaluationProvider.state;
+    switch (state) {
+      case ProviderState.NOT_READY:
+        throw const ProviderException(
+          'Provider is not ready.',
+          code: ErrorCode.PROVIDER_NOT_READY,
+        );
+      case ProviderState.FATAL:
+        throw const ProviderException(
+          'Provider is in an irrecoverable error state.',
+          code: ErrorCode.PROVIDER_FATAL,
+        );
+      default:
+        return;
+    }
   }
 
   FlagValueType _inferFlagValueType<T>(T defaultValue) {
@@ -202,10 +226,10 @@ class FeatureClient {
     T defaultValue,
     Future<FlagEvaluationResult<T>> Function(Map<String, dynamic>?) evaluator, {
     required FeatureProvider evaluationProvider,
-    Map<String, dynamic>? context,
+    EvaluationContext? context,
   }) async {
     final startTime = DateTime.now();
-    var effectiveContext = _buildEffectiveContext(context);
+    var effectiveContext = <String, dynamic>{};
     final hookData = HookData();
     final flagValueType = _inferFlagValueType(defaultValue);
     FlagEvaluationResult<T>? finalResult;
@@ -214,6 +238,7 @@ class FeatureClient {
     _metrics.flagEvaluations++;
 
     try {
+      effectiveContext = _buildEffectiveContext(context);
       effectiveContext = await _hookManager.executeHooks(
         HookStage.BEFORE,
         flagKey,
@@ -225,6 +250,7 @@ class FeatureClient {
         hookData: hookData,
       );
 
+      _ensureProviderCanEvaluate(evaluationProvider);
       finalResult = await evaluator(effectiveContext);
       evaluationDetails = _createEvaluationDetails(finalResult);
 
@@ -318,7 +344,7 @@ class FeatureClient {
     T defaultValue,
     Future<FlagEvaluationResult<T>> Function(Map<String, dynamic>?) evaluator, {
     required FeatureProvider evaluationProvider,
-    Map<String, dynamic>? context,
+    EvaluationContext? context,
   }) async {
     final result = await _evaluateFlagResult(
       flagKey,
@@ -346,7 +372,7 @@ class FeatureClient {
         context: ctx,
       ),
       evaluationProvider: evaluationProvider,
-      context: context?.attributes,
+      context: context,
     );
   }
 
@@ -363,7 +389,7 @@ class FeatureClient {
       (ctx) =>
           evaluationProvider.getStringFlag(flagKey, defaultValue, context: ctx),
       evaluationProvider: evaluationProvider,
-      context: context?.attributes,
+      context: context,
     );
   }
 
@@ -383,7 +409,7 @@ class FeatureClient {
         context: ctx,
       ),
       evaluationProvider: evaluationProvider,
-      context: context?.attributes,
+      context: context,
     );
   }
 
@@ -400,7 +426,7 @@ class FeatureClient {
       (ctx) =>
           evaluationProvider.getDoubleFlag(flagKey, defaultValue, context: ctx),
       evaluationProvider: evaluationProvider,
-      context: context?.attributes,
+      context: context,
     );
   }
 
@@ -416,7 +442,7 @@ class FeatureClient {
       (ctx) =>
           evaluationProvider.getObjectFlag(flagKey, defaultValue, context: ctx),
       evaluationProvider: evaluationProvider,
-      context: context?.attributes,
+      context: context,
     );
   }
 
@@ -427,7 +453,7 @@ class FeatureClient {
     TrackingEventDetails? trackingDetails,
   }) async {
     _metrics.trackingEvents++;
-    final effectiveContext = _buildEffectiveContext(context?.attributes);
+    final effectiveContext = _buildEffectiveContext(context);
     final trackingProvider = provider;
 
     try {
@@ -475,7 +501,7 @@ extension ClientEvaluationDetails on FeatureClient {
         context: ctx,
       ),
       evaluationProvider: evaluationProvider,
-      context: context?.attributes,
+      context: context,
     );
 
     return FlagEvaluationDetails.fromResult(result);
@@ -494,7 +520,7 @@ extension ClientEvaluationDetails on FeatureClient {
       (ctx) =>
           evaluationProvider.getStringFlag(flagKey, defaultValue, context: ctx),
       evaluationProvider: evaluationProvider,
-      context: context?.attributes,
+      context: context,
     );
 
     return FlagEvaluationDetails.fromResult(result);
@@ -516,7 +542,7 @@ extension ClientEvaluationDetails on FeatureClient {
         context: ctx,
       ),
       evaluationProvider: evaluationProvider,
-      context: context?.attributes,
+      context: context,
     );
 
     return FlagEvaluationDetails.fromResult(result);
@@ -535,7 +561,7 @@ extension ClientEvaluationDetails on FeatureClient {
       (ctx) =>
           evaluationProvider.getDoubleFlag(flagKey, defaultValue, context: ctx),
       evaluationProvider: evaluationProvider,
-      context: context?.attributes,
+      context: context,
     );
 
     return FlagEvaluationDetails.fromResult(result);
@@ -554,7 +580,7 @@ extension ClientEvaluationDetails on FeatureClient {
       (ctx) =>
           evaluationProvider.getObjectFlag(flagKey, defaultValue, context: ctx),
       evaluationProvider: evaluationProvider,
-      context: context?.attributes,
+      context: context,
     );
 
     return FlagEvaluationDetails.fromResult(result);

--- a/lib/evaluation_context.dart
+++ b/lib/evaluation_context.dart
@@ -169,6 +169,23 @@ class EvaluationContext {
     this.cacheDuration = const Duration(minutes: 5),
   });
 
+  /// Return the complete context in the legacy provider-map representation.
+  ///
+  /// Parent fields have the lowest precedence. The targeting key is emitted as
+  /// `targetingKey` so providers using the map-based compatibility interface do
+  /// not lose the subject of the evaluation.
+  Map<String, dynamic> toProviderContext() {
+    final result = <String, dynamic>{
+      ...parent?.toProviderContext() ?? const <String, dynamic>{},
+      ...attributes,
+    };
+    final effectiveTargetingKey = targetingKey ?? parent?.targetingKey;
+    if (effectiveTargetingKey != null) {
+      result['targetingKey'] = effectiveTargetingKey;
+    }
+    return result;
+  }
+
   /// Get an attribute value, checking parent context if not found
   dynamic getAttribute(String key) {
     return attributes[key] ?? parent?.getAttribute(key);

--- a/lib/feature_provider.dart
+++ b/lib/feature_provider.dart
@@ -132,7 +132,7 @@ class FlagEvaluationDetails<T> {
   final String? errorMessage;
   final String? reason;
   final String? variant;
-  final Map<String, dynamic>? flagMetadata;
+  final Map<String, dynamic> flagMetadata;
   final DateTime timestamp;
 
   FlagEvaluationDetails({
@@ -142,7 +142,7 @@ class FlagEvaluationDetails<T> {
     this.errorMessage,
     this.reason,
     this.variant,
-    this.flagMetadata,
+    this.flagMetadata = const {},
   }) : timestamp = DateTime.now();
 
   factory FlagEvaluationDetails.fromResult(FlagEvaluationResult<T> result) {
@@ -153,7 +153,7 @@ class FlagEvaluationDetails<T> {
       errorMessage: result.errorMessage,
       reason: result.reason,
       variant: result.variant,
-      flagMetadata: result.details,
+      flagMetadata: Map.unmodifiable(result.details ?? const {}),
     );
   }
 }

--- a/lib/open_feature_api.dart
+++ b/lib/open_feature_api.dart
@@ -11,13 +11,23 @@ import 'provider_lifecycle.dart';
 import 'src/provider_lifecycle_manager.dart';
 
 class OpenFeatureEvaluationContext {
+  final String? targetingKey;
   final Map<String, dynamic> attributes;
 
-  OpenFeatureEvaluationContext(this.attributes);
+  OpenFeatureEvaluationContext(
+    Map<String, dynamic> attributes, {
+    this.targetingKey,
+  }) : attributes = Map.unmodifiable(Map.of(attributes));
 
   OpenFeatureEvaluationContext merge(OpenFeatureEvaluationContext other) {
-    return OpenFeatureEvaluationContext({...attributes, ...other.attributes});
+    return OpenFeatureEvaluationContext({
+      ...attributes,
+      ...other.attributes,
+    }, targetingKey: other.targetingKey ?? targetingKey);
   }
+
+  EvaluationContext toEvaluationContext() =>
+      EvaluationContext(targetingKey: targetingKey, attributes: attributes);
 }
 
 abstract class OpenFeatureHook {
@@ -370,6 +380,9 @@ class OpenFeatureAPI {
     FeatureProvider resolveProvider() =>
         _resolveProviderForClient(name, domain);
     final selectedProvider = resolveProvider();
+    EvaluationContext resolveApiContext() =>
+        _globalContext?.toEvaluationContext() ??
+        const EvaluationContext(attributes: {});
 
     final hookManager = HookManager();
     for (final hook in _hooks) {
@@ -379,9 +392,8 @@ class OpenFeatureAPI {
     return FeatureClient(
       metadata: ClientMetadata(name: name),
       hookManager: hookManager,
-      apiContext: _globalContext != null
-          ? EvaluationContext(attributes: _globalContext!.attributes)
-          : const EvaluationContext(attributes: {}),
+      apiContext: resolveApiContext(),
+      apiContextResolver: resolveApiContext,
       defaultContext: const EvaluationContext(attributes: {}),
       provider: selectedProvider,
       providerResolver: resolveProvider,

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -193,6 +193,39 @@ class ThrowingProvider extends MockProvider {
   }
 }
 
+class StateProvider extends MockProvider {
+  final ProviderState providerState;
+
+  StateProvider(super.flags, this.providerState);
+
+  @override
+  ProviderState get state => providerState;
+}
+
+enum ThrowingHookStage { before, after }
+
+class ThrowingHook extends BaseHook {
+  final ThrowingHookStage stage;
+
+  ThrowingHook(this.stage)
+    : super(metadata: HookMetadata(name: 'ThrowingHook-${stage.name}'));
+
+  @override
+  Future<Map<String, dynamic>?> before(HookContext context) async {
+    if (stage == ThrowingHookStage.before) {
+      throw StateError('before failed');
+    }
+    return null;
+  }
+
+  @override
+  Future<void> after(HookContext context) async {
+    if (stage == ThrowingHookStage.after) {
+      throw StateError('after failed');
+    }
+  }
+}
+
 class LifecycleHook extends BaseHook {
   final List<String> calls = [];
   EvaluationDetails? finalDetails;
@@ -355,34 +388,48 @@ void main() {
       expect(provider.booleanCalls, equals(1));
     });
 
-    test('tracking merges api, transaction, client, and invocation contexts', () async {
-      final trackingProvider = TrackingMockProvider({'test-flag': true});
-      final transactionManager = TransactionContextManager();
-      client = FeatureClient(
-        metadata: ClientMetadata(name: 'test-client'),
-        hookManager: hookManager,
-        apiContext: const EvaluationContext(
-          attributes: {'global': 'value'},
-        ),
-        defaultContext: const EvaluationContext(
-          attributes: {'client': 'value'},
-        ),
-        provider: trackingProvider,
-        transactionManager: transactionManager,
-      );
-
-      await transactionManager.withContext('tx', {'requestId': '123'}, () async {
-        await client.track(
-          'checkout',
-          context: const EvaluationContext(attributes: {'userId': 'u-1'}),
+    test(
+      'tracking merges api, transaction, client, and invocation contexts',
+      () async {
+        final trackingProvider = TrackingMockProvider({'test-flag': true});
+        final transactionManager = TransactionContextManager();
+        client = FeatureClient(
+          metadata: ClientMetadata(name: 'test-client'),
+          hookManager: hookManager,
+          apiContext: const EvaluationContext(attributes: {'global': 'value'}),
+          defaultContext: const EvaluationContext(
+            attributes: {'client': 'value'},
+          ),
+          provider: trackingProvider,
+          transactionManager: transactionManager,
         );
-      });
 
-      expect(trackingProvider.lastTrackingContext?['global'], equals('value'));
-      expect(trackingProvider.lastTrackingContext?['requestId'], equals('123'));
-      expect(trackingProvider.lastTrackingContext?['client'], equals('value'));
-      expect(trackingProvider.lastTrackingContext?['userId'], equals('u-1'));
-    });
+        await transactionManager.withContext(
+          'tx',
+          {'requestId': '123'},
+          () async {
+            await client.track(
+              'checkout',
+              context: const EvaluationContext(attributes: {'userId': 'u-1'}),
+            );
+          },
+        );
+
+        expect(
+          trackingProvider.lastTrackingContext?['global'],
+          equals('value'),
+        );
+        expect(
+          trackingProvider.lastTrackingContext?['requestId'],
+          equals('123'),
+        );
+        expect(
+          trackingProvider.lastTrackingContext?['client'],
+          equals('value'),
+        );
+        expect(trackingProvider.lastTrackingContext?['userId'], equals('u-1'));
+      },
+    );
 
     test('client handlers receive forwarded events', () async {
       final controller = StreamController<OpenFeatureEvent>.broadcast();
@@ -413,39 +460,110 @@ void main() {
       await controller.close();
     });
 
-    test('provider error result triggers error hooks instead of after hooks', () async {
-      final lifecycleHook = LifecycleHook();
-      hookManager.addHook(lifecycleHook);
+    test(
+      'provider error result triggers error hooks instead of after hooks',
+      () async {
+        final lifecycleHook = LifecycleHook();
+        hookManager.addHook(lifecycleHook);
 
-      final result = await client.getBooleanFlag(
-        'missing-flag',
-        defaultValue: false,
+        final result = await client.getBooleanFlag(
+          'missing-flag',
+          defaultValue: false,
+        );
+
+        expect(result, isFalse);
+        expect(lifecycleHook.calls, equals(['before', 'error', 'finally']));
+        expect(lifecycleHook.finalDetails?.value, isFalse);
+        expect(lifecycleHook.lastError, isA<ProviderException>());
+        expect(
+          (lifecycleHook.lastError as ProviderException).code,
+          equals(ErrorCode.FLAG_NOT_FOUND),
+        );
+      },
+    );
+
+    test(
+      'preserves ProviderException error codes from thrown provider errors',
+      () async {
+        final throwingProvider = ThrowingProvider(
+          {'test-flag': true},
+          const ProviderException(
+            'provider unavailable',
+            code: ErrorCode.PROVIDER_NOT_READY,
+          ),
+        );
+
+        client = FeatureClient(
+          metadata: ClientMetadata(name: 'test-client'),
+          hookManager: hookManager,
+          defaultContext: context,
+          provider: throwingProvider,
+        );
+
+        final details = await client.getBooleanDetails(
+          'test-flag',
+          defaultValue: false,
+        );
+
+        expect(details.value, isFalse);
+        expect(details.errorCode, equals(ErrorCode.PROVIDER_NOT_READY));
+        expect(details.errorMessage, equals('provider unavailable'));
+      },
+    );
+
+    for (final testCase in <(ProviderState, ErrorCode)>[
+      (ProviderState.NOT_READY, ErrorCode.PROVIDER_NOT_READY),
+      (ProviderState.FATAL, ErrorCode.PROVIDER_FATAL),
+    ]) {
+      test(
+        '${testCase.$1.name} defaults without calling the provider',
+        () async {
+          final stateProvider = StateProvider({'test-flag': true}, testCase.$1);
+          final lifecycleHook = LifecycleHook();
+          hookManager.addHook(lifecycleHook);
+          client = FeatureClient(
+            metadata: ClientMetadata(name: 'test-client'),
+            hookManager: hookManager,
+            defaultContext: context,
+            provider: stateProvider,
+          );
+
+          final details = await client.getBooleanDetails(
+            'test-flag',
+            defaultValue: false,
+          );
+
+          expect(details.value, isFalse);
+          expect(details.reason, equals('ERROR'));
+          expect(details.errorCode, equals(testCase.$2));
+          expect(stateProvider.booleanCalls, isZero);
+          expect(lifecycleHook.calls, equals(['before', 'error', 'finally']));
+        },
       );
+    }
 
-      expect(result, isFalse);
-      expect(lifecycleHook.calls, equals(['before', 'error', 'finally']));
-      expect(lifecycleHook.finalDetails?.value, isFalse);
-      expect(lifecycleHook.lastError, isA<ProviderException>());
-      expect(
-        (lifecycleHook.lastError as ProviderException).code,
-        equals(ErrorCode.FLAG_NOT_FOUND),
-      );
-    });
+    for (final stage in ThrowingHookStage.values) {
+      test('${stage.name} hook exceptions never escape evaluation', () async {
+        hookManager.addHook(ThrowingHook(stage));
 
-    test('preserves ProviderException error codes from thrown provider errors', () async {
-      final throwingProvider = ThrowingProvider(
-        {'test-flag': true},
-        const ProviderException(
-          'provider unavailable',
-          code: ErrorCode.PROVIDER_NOT_READY,
-        ),
-      );
+        final details = await client.getBooleanDetails(
+          'test-flag',
+          defaultValue: false,
+        );
 
+        expect(details.value, isFalse);
+        expect(details.reason, equals('ERROR'));
+        expect(details.errorCode, equals(ErrorCode.GENERAL));
+      });
+    }
+
+    test('context resolver exceptions never escape evaluation', () async {
       client = FeatureClient(
         metadata: ClientMetadata(name: 'test-client'),
         hookManager: hookManager,
         defaultContext: context,
-        provider: throwingProvider,
+        apiContextResolver: () => throw StateError('context failed'),
+        provider: provider,
       );
 
       final details = await client.getBooleanDetails(
@@ -454,49 +572,85 @@ void main() {
       );
 
       expect(details.value, isFalse);
-      expect(details.errorCode, equals(ErrorCode.PROVIDER_NOT_READY));
-      expect(details.errorMessage, equals('provider unavailable'));
+      expect(details.reason, equals('ERROR'));
+      expect(details.errorCode, equals(ErrorCode.GENERAL));
+      expect(provider.booleanCalls, isZero);
     });
 
-    test('before hook context updates are merged into provider evaluation context', () async {
-      final capturingProvider = ContextCapturingProvider({'test-flag': true});
-      final transactionManager = TransactionContextManager();
-      final lifecycleHook = LifecycleHook(
-        beforeUpdates: {'hook': 'value', 'userId': 'hook-user'},
-      );
-      hookManager.addHook(lifecycleHook);
+    test('detailed results always expose immutable flag metadata', () async {
+      final details = await client.getBooleanDetails('test-flag');
 
-      client = FeatureClient(
-        metadata: ClientMetadata(name: 'test-client'),
-        hookManager: hookManager,
-        apiContext: const EvaluationContext(
-          attributes: {'global': 'value'},
-        ),
-        defaultContext: const EvaluationContext(
-          attributes: {'client': 'value'},
-        ),
-        provider: capturingProvider,
-        transactionManager: transactionManager,
+      expect(details.flagMetadata, isEmpty);
+      expect(
+        () => details.flagMetadata['new'] = 'value',
+        throwsUnsupportedError,
       );
+    });
 
-      await transactionManager.withContext('tx', {'requestId': '123'}, () async {
-        await client.getBooleanFlag(
-          'test-flag',
-          context: const EvaluationContext(attributes: {'userId': 'invocation'}),
+    test(
+      'before hook context updates are merged into provider evaluation context',
+      () async {
+        final capturingProvider = ContextCapturingProvider({'test-flag': true});
+        final transactionManager = TransactionContextManager();
+        final lifecycleHook = LifecycleHook(
+          beforeUpdates: {
+            'hook': 'value',
+            'userId': 'hook-user',
+            'targetingKey': 'hook-target',
+          },
         );
-      });
+        hookManager.addHook(lifecycleHook);
 
-      expect(capturingProvider.lastEvaluationContext?['global'], equals('value'));
-      expect(
-        capturingProvider.lastEvaluationContext?['requestId'],
-        equals('123'),
-      );
-      expect(capturingProvider.lastEvaluationContext?['client'], equals('value'));
-      expect(capturingProvider.lastEvaluationContext?['hook'], equals('value'));
-      expect(
-        capturingProvider.lastEvaluationContext?['userId'],
-        equals('hook-user'),
-      );
-    });
+        client = FeatureClient(
+          metadata: ClientMetadata(name: 'test-client'),
+          hookManager: hookManager,
+          apiContext: const EvaluationContext(attributes: {'global': 'value'}),
+          defaultContext: const EvaluationContext(
+            attributes: {'client': 'value'},
+          ),
+          provider: capturingProvider,
+          transactionManager: transactionManager,
+        );
+
+        await transactionManager.withContext(
+          'tx',
+          {'requestId': '123'},
+          () async {
+            await client.getBooleanFlag(
+              'test-flag',
+              context: const EvaluationContext(
+                targetingKey: 'invocation-target',
+                attributes: {'userId': 'invocation'},
+              ),
+            );
+          },
+        );
+
+        expect(
+          capturingProvider.lastEvaluationContext?['global'],
+          equals('value'),
+        );
+        expect(
+          capturingProvider.lastEvaluationContext?['requestId'],
+          equals('123'),
+        );
+        expect(
+          capturingProvider.lastEvaluationContext?['client'],
+          equals('value'),
+        );
+        expect(
+          capturingProvider.lastEvaluationContext?['hook'],
+          equals('value'),
+        );
+        expect(
+          capturingProvider.lastEvaluationContext?['targetingKey'],
+          equals('hook-target'),
+        );
+        expect(
+          capturingProvider.lastEvaluationContext?['userId'],
+          equals('hook-user'),
+        );
+      },
+    );
   });
 }

--- a/test/evaluation_context_test.dart
+++ b/test/evaluation_context_test.dart
@@ -10,8 +10,10 @@ void main() {
     });
 
     test('evaluates IN_LIST operator', () {
-      final rule = TargetingRule(
-          'role', TargetingOperator.IN_LIST, ['admin', 'superuser']);
+      final rule = TargetingRule('role', TargetingOperator.IN_LIST, [
+        'admin',
+        'superuser',
+      ]);
       expect(rule.evaluate({'role': 'admin'}), isTrue);
       expect(rule.evaluate({'role': 'user'}), isFalse);
     });
@@ -36,9 +38,30 @@ void main() {
   });
 
   group('EvaluationContext', () {
+    test(
+      'provider context preserves inherited targeting key and attributes',
+      () {
+        final parent = EvaluationContext(
+          targetingKey: 'parent-user',
+          attributes: {'region': 'us', 'shared': 'parent'},
+        );
+        final child = parent.createChild({'shared': 'child'});
+
+        expect(
+          child.toProviderContext(),
+          equals({
+            'region': 'us',
+            'shared': 'child',
+            'targetingKey': 'parent-user',
+          }),
+        );
+      },
+    );
+
     test('retrieves attributes from parent context', () {
-      final parent =
-          EvaluationContext(attributes: {'env': 'prod', 'shared': 'parent'});
+      final parent = EvaluationContext(
+        attributes: {'env': 'prod', 'shared': 'parent'},
+      );
 
       final child = EvaluationContext(
         attributes: {'region': 'EU', 'shared': 'child'},

--- a/test/open_feature_api_test.dart
+++ b/test/open_feature_api_test.dart
@@ -8,6 +8,8 @@ class TestProvider implements FeatureProvider {
   final String _providerName;
   ProviderState _state;
   final bool _shouldFailInitialization;
+  Map<String, dynamic>? lastEvaluationContext;
+  int booleanEvaluationCount = 0;
 
   TestProvider(
     this._flags, {
@@ -69,6 +71,8 @@ class TestProvider implements FeatureProvider {
     bool defaultValue, {
     Map<String, dynamic>? context,
   }) async {
+    booleanEvaluationCount++;
+    lastEvaluationContext = context == null ? null : {...context};
     if (_state != ProviderState.READY) {
       return FlagEvaluationResult.error(
         flagKey,
@@ -198,6 +202,41 @@ void main() {
       expect(merged.attributes['local'], equals('value'));
     });
 
+    test(
+      'existing clients use later global context and targeting-key changes',
+      () async {
+        final api = OpenFeatureAPI();
+        final provider = TestProvider({'test-flag': true});
+        await api.setProviderAndWait(provider);
+        api.setGlobalContext(
+          OpenFeatureEvaluationContext({
+            'version': 'first',
+          }, targetingKey: 'first-user'),
+        );
+        final client = api.getClient('test-client');
+
+        await client.getBooleanFlag('test-flag');
+        expect(provider.lastEvaluationContext?['version'], equals('first'));
+        expect(
+          provider.lastEvaluationContext?['targetingKey'],
+          equals('first-user'),
+        );
+
+        api.setGlobalContext(
+          OpenFeatureEvaluationContext({
+            'version': 'second',
+          }, targetingKey: 'second-user'),
+        );
+        await client.getBooleanFlag('test-flag');
+
+        expect(provider.lastEvaluationContext?['version'], equals('second'));
+        expect(
+          provider.lastEvaluationContext?['targetingKey'],
+          equals('second-user'),
+        );
+      },
+    );
+
     test('evaluates boolean flag with hooks using new API', () async {
       final api = OpenFeatureAPI();
       final provider = TestProvider({'test-flag': true});
@@ -237,14 +276,12 @@ void main() {
 
     test('routes domain-bound clients to registered providers', () async {
       final api = OpenFeatureAPI();
-      final defaultProvider = TestProvider(
-        {'test': true},
-        providerName: 'default-provider',
-      );
-      final secondaryProvider = TestProvider(
-        {'test': false},
-        providerName: 'secondary-provider',
-      );
+      final defaultProvider = TestProvider({
+        'test': true,
+      }, providerName: 'default-provider');
+      final secondaryProvider = TestProvider({
+        'test': false,
+      }, providerName: 'secondary-provider');
 
       await api.setProvider(defaultProvider);
       api.registerProvider(secondaryProvider);


### PR DESCRIPTION
## Summary

- short-circuit NOT_READY and FATAL providers with the caller default and specification error code
- preserve targeting keys through context merging and legacy provider-map adaptation
- let existing clients observe later global context changes
- return an immutable empty metadata record when providers omit flag metadata
- contain provider, hook, and context-resolution failures inside evaluation

## QA

- dart pub get
- dart analyze (no issues)
- dart test (151 tests passed)
- git diff --check

This is a source-compatible P0 safety slice. Requiring explicit default parameters remains a deliberately staged breaking-contract change.

Tracks #121.