### PR TITLE
chore(ci): harden release workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/workflows/contributor-workflow.yml
+++ b/.github/workflows/contributor-workflow.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Dart
-        uses: dart-lang/setup-dart@v1
+        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1
         # with:
         #   sdk: stable   # (optional; stable is the default)
 
@@ -124,7 +124,7 @@ jobs:
 
       - name: Upload Analysis Artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: core-sdk-analysis
           path: |

--- a/.github/workflows/coverage-workflow.yml
+++ b/.github/workflows/coverage-workflow.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Dart
-        uses: dart-lang/setup-dart@v1
+        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1
         with:
           sdk: stable
 
@@ -38,7 +38,7 @@ jobs:
         run: ls -al coverage
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-report
           path: coverage/lcov.info
@@ -50,10 +50,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: coverage-report
           path: coverage
@@ -62,7 +62,7 @@ jobs:
         run: ls -al coverage
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV__UPLOAD_TOKEN }} # omit for public repos if you want
           slug: open-feature/dart-server-sdk

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -23,11 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
@@ -46,7 +46,7 @@ jobs:
 
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: pr-title-lint-error
           delete: true

--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -3,19 +3,17 @@ name: Notifications
 on:
   push:
     branches:
-     - main
-     - qa
-     - development
+      - main
+      - development
 
 jobs:
   notify:
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
-      id-token: 'write'
     
     steps:
       - name: Notify Google Chat
-        uses: SimonScholz/google-chat-action@main
+        uses: SimonScholz/google-chat-action@e90269b18c270452c57f8f6c6eebabc49ab27943
         with:
           webhookUrl: '${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}'

--- a/.github/workflows/parent-pipeline.yml
+++ b/.github/workflows/parent-pipeline.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - qa
       - development
 
   pull_request:

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -30,8 +30,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         sdk: [3.12.2, stable, beta]
     steps:
-      - uses: actions/checkout@v7
-      - uses: dart-lang/setup-dart@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1
         with:
           sdk: ${{ matrix.sdk }}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,11 +8,12 @@ on:
 jobs:
   publish:
     permissions:
+      contents: read
       id-token: write # Required for authentication using OIDC
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dart-lang/setup-dart@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1
       - name: Install dependencies
         run: dart pub get
       - name: Publish

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,16 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # for googleapis/release-please-action to create release commit
+      issues: write # for googleapis/release-please-action to update release labels
       pull-requests: write # for googleapis/release-please-action to create release PR
     # Release-please creates a PR that tracks all changes
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
-          command: manifest
           token: ${{secrets.RELEASE_PLEASE_ACTION_TOKEN}}
-          default-branch: main
-          signoff: "OpenFeature Bot <109696520+openfeaturebot@users.noreply.github.com>"
+          target-branch: main
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
       - name: Dump Release Please Output
         env:
           RELEASE_PLEASE_OUTPUT: ${{ toJSON(steps.release.outputs) }}

--- a/.github/workflows/validation-workflow.yml
+++ b/.github/workflows/validation-workflow.yml
@@ -1,4 +1,4 @@
-# This workflow valides that branch and commit names are standardized.
+# This workflow validates that branch and commit names are standardized.
 
 name: Validation Workflow
 
@@ -21,13 +21,13 @@ jobs:
           BRANCH_NAME="${{ inputs.branch_name }}"
           echo "Branch name: $BRANCH_NAME"
 
-          if [[ "$BRANCH_NAME" =~ ^(qa|development|main|release-please--branches--main--components--openfeature_dart_server_sdk)$ ]]; then
-            echo "✅ Branch name '$BRANCH_NAME' is valid for protected branches (qa, development, main)."
+          if [[ "$BRANCH_NAME" =~ ^(development|main|release-please--branches--main--components--openfeature_dart_server_sdk)$ ]]; then
+            echo "✅ Branch name '$BRANCH_NAME' is valid for a long-lived branch."
           elif [[ "$BRANCH_NAME" =~ ^(feat|fix|hotfix|chore|test|refactor|release|admin|docs|ci)/[a-z0-9._-]+$ ]]; then
             echo "✅ Branch name '$BRANCH_NAME' follows the naming convention."
           else
             echo "❌ Branch name '$BRANCH_NAME' does not follow the naming convention: <type>/<branch-name>"
-            echo "Valid types: feat, fix, hotfix, chore, test, refactor, release, admin, docs, ci, qa, main, development"
+            echo "Valid types: feat, fix, hotfix, chore, test, refactor, release, admin, docs, ci, main, development"
             exit 1
           fi
 
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Validate Dart SDK versions in all pubspec.yaml files
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,22 +173,22 @@ We follow [Conventional Commits](https://www.conventionalcommits.org) to ensure 
 
 ---
 
-### **Branching Rules and Protection**
+### **Branching and Release Flow**
 
-To maintain consistency and ensure stability, we enforce the following **branch protection rules**:
+The repository currently uses two long-lived branches:
 
-#### **Protected Branches**
+- `development` is the integration and QA branch.
+- `main` is the protected production and release branch.
 
-- **Branches**: `main`, `qa`, `development`
+There is no `qa` branch. Validate changes on `development` before promoting
+them to `main`.
 
-- **Rules**:
-  - Direct **pushes** are not allowed.
-  - Changes must go through a **pull request** and pass all required checks before merging.
-  - At least **1 reviewer** must approve pull requests.
-  - Status checks:
-    - **Branch name validation** must pass.
-    - **Commit message validation** must pass.
-    - Relevant workflows (e.g., `main-workflow`, `qa-workflow`) must pass.
+The normal change path is:
+
+1. Open a pull request from a short-lived branch into `development`.
+2. Complete automated checks and development QA.
+3. Promote the tested `development` commit to `main` through a pull request.
+4. Satisfy the `main` ruleset, including its required status checks and review.
 
 #### **Unprotected Branches**
 - Feature and other short-lived branches (e.g., `feat/add-auth`, `fix/login-error`) are not protected.
@@ -197,7 +197,7 @@ To maintain consistency and ensure stability, we enforce the following **branch 
 #### **Branch Lifecycle**
 - **Feature, Fix, Hotfix, Test Branches**:
   - Created by developers for specific tasks.
-  - Merged into `main`, `qa`, or `development` branches through pull requests.
+  - Merged into `development` through pull requests.
   - Deleted after merging.
 
 ---
@@ -208,15 +208,15 @@ To maintain consistency and ensure stability, we enforce the following **branch 
    - Example: `feat/add-user-auth`.
    - Pushes to these branches are allowed without restrictions.
 
-2. **Pull Requests into Protected Branches**:
+2. **Pull Requests into Development**:
 
-   - Protected branches (`main`, `qa`, `development`) require pull requests.
+   - Open short-lived branches against `development` for integration and QA.
    - Pull requests trigger workflows for testing and validation.
 
-3. **Validation on Push and Pull Requests**:
+3. **Promotion to Main**:
    - Short-lived branches are validated when a pull request is opened or updated.
-   - `main`, `qa`, and `development` are validated again after merged changes are pushed.
-   - Protected branches also enforce workflow checks and reviews.
+   - `development` is validated again after merged changes are pushed.
+   - Only tested `development` changes are promoted to protected `main`.
 
 ---
 
@@ -365,7 +365,7 @@ Pull requests often receive feedback. Follow these steps to address requested ch
 3. **Rebase and Squash Commits**:
    - If your branch has multiple commits and needs to be cleaned up:
      ```bash
-     git rebase -i origin/qa
+     git rebase -i origin/development
      git push --force-with-lease
      ```
 


### PR DESCRIPTION
## Summary

- upgrade Release Please from v3 to the reviewed v5.0.0 commit and use its manifest inputs
- pin every third-party GitHub Action to a reviewed commit SHA
- add weekly Dependabot updates for GitHub Actions pins
- remove the nonexistent qa branch from workflows and branch validation
- document development as the integration/QA branch and main as the protected release branch
- remove unnecessary notification OIDC permission and restore publish checkout read permission

## QA

- actionlint 1.7.12 (clean; release checksum verified before execution)
- dart pub get
- dart analyze (no issues)
- dart test (151 tests passed)
- git diff --check

The branch includes the current development head from #126 so CI validates the combined state.