### PR TITLE
fix(ci): validate minimum dependencies

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -43,3 +43,23 @@ jobs:
 
       - name: Run tests
         run: dart test
+
+  minimum-dependencies:
+    name: minimum dependencies
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1
+        with:
+          sdk: 3.12.2
+
+      - name: Install minimum dependencies
+        run: dart pub downgrade
+
+      - name: Analyze
+        run: dart analyze
+
+      - name: Run tests
+        run: dart test

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - development
   pull_request:
     types:
       - opened

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,10 @@ dependencies:
 dev_dependencies:
   # For testing
   coverage: ^1.15.0 # For Code Coverage Reports
+  # Dart 3.12 removed the legacy frontend_server.dart.snapshot layout used by
+  # frontend_server_client 3.x. Keep minimum-dependency test runs on the
+  # SDK-layout-aware client.
+  frontend_server_client: ^4.0.0
   git_hooks: ^1.0.2 # Provides hooks for locla ddevelopment
   lints: ^6.0.0 # Recommended lints for maintaining code quality
   mockito: ^5.5.1 # For mocking objects in unit tests


### PR DESCRIPTION
﻿## Summary

- constrain `frontend_server_client` to the Dart 3 SDK-layout-aware 4.x release
- add a dedicated Ubuntu/Dart 3.12.2 minimum-dependency CI job
- run the full OS/SDK matrix on exact development merge commits
- run analysis and all tests after `dart pub downgrade`

## Why

The existing latest-dependency matrix was green, but `dart pub downgrade` selected `frontend_server_client` 3.2.0. That client looks for the removed `frontend_server.dart.snapshot` SDK layout, so all test files failed to load on Dart 3.12.2. Pinning the compatible lower bound and continuously testing minimum resolution prevents that release blind spot from recurring.

## QA

- actionlint 1.7.12
- `dart format --output=none --set-exit-if-changed .` (34 files, unchanged)
- `dart pub downgrade`
- `dart analyze` (no issues on minimum dependencies)
- `dart test` (151 passed on minimum dependencies)
- `dart pub upgrade`
