### PR TITLE
fix(lifecycle): address provider review findings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Here's the updated **Branching and Commit Guidelines** section with the adjustme
 ### **Branch Naming Conventions**
 
 Follow these conventions when creating branches for pull requests:
-```
+```text
 <type>/<branch-name>
 ```
 

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -81,7 +81,15 @@ class FeatureClient {
        _transactionManager = transactionManager ?? TransactionContextManager() {
     if (_providerResolver == null &&
         providerStatus == ProviderState.NOT_READY) {
-      this.provider.initialize();
+      unawaited(
+        this.provider.initialize().catchError((Object error, StackTrace stack) {
+          _logger.severe(
+            'Provider initialization failed: $error',
+            error,
+            stack,
+          );
+        }),
+      );
     }
 
     if (eventStream != null) {
@@ -144,6 +152,7 @@ class FeatureClient {
         evaluationProvider.state;
     switch (state) {
       case ProviderState.NOT_READY:
+      case ProviderState.SHUTDOWN:
         throw const ProviderException(
           'Provider is not ready.',
           code: ErrorCode.PROVIDER_NOT_READY,
@@ -453,10 +462,10 @@ class FeatureClient {
     TrackingEventDetails? trackingDetails,
   }) async {
     _metrics.trackingEvents++;
-    final effectiveContext = _buildEffectiveContext(context);
-    final trackingProvider = provider;
 
     try {
+      final effectiveContext = _buildEffectiveContext(context);
+      final trackingProvider = provider;
       await trackingProvider.track(
         trackingEventName,
         evaluationContext: effectiveContext,

--- a/lib/feature_provider.dart
+++ b/lib/feature_provider.dart
@@ -142,8 +142,9 @@ class FlagEvaluationDetails<T> {
     this.errorMessage,
     this.reason,
     this.variant,
-    this.flagMetadata = const {},
-  }) : timestamp = DateTime.now();
+    Map<String, dynamic> flagMetadata = const {},
+  }) : flagMetadata = Map.unmodifiable(flagMetadata),
+       timestamp = DateTime.now();
 
   factory FlagEvaluationDetails.fromResult(FlagEvaluationResult<T> result) {
     return FlagEvaluationDetails(
@@ -153,7 +154,7 @@ class FlagEvaluationDetails<T> {
       errorMessage: result.errorMessage,
       reason: result.reason,
       variant: result.variant,
-      flagMetadata: Map.unmodifiable(result.details ?? const {}),
+      flagMetadata: result.details ?? const {},
     );
   }
 }

--- a/lib/open_feature_api.dart
+++ b/lib/open_feature_api.dart
@@ -159,10 +159,12 @@ class OpenFeatureAPI {
   final List<OpenFeatureHook> _hooks = [];
   OpenFeatureEvaluationContext? _globalContext;
   StreamSubscription<Domain>? _domainSubscription;
+  StreamSubscription<LogRecord>? _logSubscription;
 
   final StreamController<FeatureProvider> _providerStreamController;
   final StreamController<OpenFeatureEvent> _eventStreamController;
   final StreamController<Map<String, String>> _domainUpdatesController;
+  Future<void>? _disposeFuture;
 
   OpenFeatureAPI._internal()
     : _providerStreamController = StreamController<FeatureProvider>.broadcast(),
@@ -187,7 +189,7 @@ class OpenFeatureAPI {
 
   void _configureLogging() {
     Logger.root.level = Level.ALL;
-    Logger.root.onRecord.listen((record) {
+    _logSubscription = Logger.root.onRecord.listen((record) {
       print(
         '${record.time} [${record.level.name}] ${record.loggerName}: ${record.message}',
       );
@@ -297,7 +299,7 @@ class OpenFeatureAPI {
     if (id.isEmpty) {
       throw ArgumentError.value(id, 'providerId', 'must not be empty');
     }
-    _lifecycleManager.statusOf(provider);
+    _lifecycleManager.track(provider);
     _providerRegistry[id] = provider;
     _activatePendingBindings(id, provider);
     return id;
@@ -313,17 +315,14 @@ class OpenFeatureAPI {
         .map((entry) => entry.key)
         .toList();
 
-    for (final domain in pendingDomains) {
+    if (pendingDomains.isNotEmpty) {
       unawaited(
-        _bindDomainProvider(domain, providerId, provider).catchError((
-          Object error,
-        ) {
+        _initializeAndBindDomainProvider(
+          pendingDomains,
+          providerId,
+          provider,
+        ).catchError((Object error) {
           _logger.severe('Failed to activate provider $providerId: $error');
-        }),
-      );
-      unawaited(
-        _lifecycleManager.initialize(provider).catchError((Object error) {
-          _logger.severe('Failed to initialize provider $providerId: $error');
         }),
       );
     }
@@ -365,6 +364,12 @@ class OpenFeatureAPI {
     final directlyBoundProvider = _domainProviderBindings[bindingKey];
     if (directlyBoundProvider != null) {
       return directlyBoundProvider;
+    }
+
+    // A name-first or asynchronous binding is not active until provider
+    // initialization and the direct binding both complete.
+    if (_domainProviderIds.containsKey(bindingKey)) {
+      return _provider;
     }
 
     final boundProviderName = _domainManager.getProviderForClient(bindingKey);
@@ -453,15 +458,12 @@ class OpenFeatureAPI {
     }
 
     unawaited(
-      _bindDomainProvider(clientId, providerId, provider).catchError((
-        Object error,
-      ) {
+      _initializeAndBindDomainProvider(
+        [clientId],
+        providerId,
+        provider,
+      ).catchError((Object error) {
         _logger.severe('Failed to bind provider $providerId: $error');
-      }),
-    );
-    unawaited(
-      _lifecycleManager.initialize(provider).catchError((Object error) {
-        _logger.severe('Failed to initialize provider $providerId: $error');
       }),
     );
   }
@@ -475,8 +477,7 @@ class OpenFeatureAPI {
       throw ArgumentError.value(providerId, 'providerId', 'is not registered');
     }
 
-    await _lifecycleManager.initialize(provider);
-    await _bindDomainProvider(clientId, providerId, provider);
+    await _initializeAndBindDomainProvider([clientId], providerId, provider);
   }
 
   Future<void> setProviderForDomainAndWait(
@@ -485,8 +486,18 @@ class OpenFeatureAPI {
     String? providerId,
   }) async {
     final id = registerProvider(provider, providerId: providerId);
+    await _initializeAndBindDomainProvider([domain], id, provider);
+  }
+
+  Future<void> _initializeAndBindDomainProvider(
+    Iterable<String> domains,
+    String providerId,
+    FeatureProvider provider,
+  ) async {
     await _lifecycleManager.initialize(provider);
-    await _bindDomainProvider(domain, id, provider);
+    for (final domain in domains) {
+      await _bindDomainProvider(domain, providerId, provider);
+    }
   }
 
   Future<void> _bindDomainProvider(
@@ -596,8 +607,11 @@ class OpenFeatureAPI {
     _eventStreamController.add(event);
   }
 
-  Future<void> dispose() async {
+  Future<void> dispose() => _disposeFuture ??= _dispose();
+
+  Future<void> _dispose() async {
     await _domainSubscription?.cancel();
+    await _logSubscription?.cancel();
     await _lifecycleManager.dispose();
     _domainManager.dispose();
     await _providerStreamController.close();
@@ -605,9 +619,17 @@ class OpenFeatureAPI {
     await _domainUpdatesController.close();
   }
 
-  static void resetInstance() {
-    _instance?.dispose();
-    _instance = null;
+  /// Disposes the current singleton before allowing a replacement instance.
+  static Future<void> resetInstance() async {
+    final instance = _instance;
+    if (instance == null) {
+      return;
+    }
+
+    await instance.dispose();
+    if (identical(_instance, instance)) {
+      _instance = null;
+    }
   }
 
   Stream<FeatureProvider> get providerUpdates =>

--- a/lib/src/provider_lifecycle_manager.dart
+++ b/lib/src/provider_lifecycle_manager.dart
@@ -13,6 +13,8 @@ typedef ProviderLifecycleEventHandler =
 /// Providers without that capability are supported by a deprecated compatibility
 /// path that derives ready/error events from lifecycle return values and state.
 class ProviderLifecycleManager {
+  static const Duration _lifecycleEventTimeout = Duration(seconds: 1);
+
   final ProviderLifecycleEventHandler _onProviderEvent;
   final HashMap<FeatureProvider, _ProviderLifecycleRecord> _records =
       HashMap.identity();
@@ -41,6 +43,12 @@ class ProviderLifecycleManager {
 
   bool usesLegacyLifecycle(FeatureProvider provider) =>
       _recordFor(provider).usesLegacyLifecycle;
+
+  /// Starts lifecycle tracking without relying on a status lookup for its
+  /// side effect.
+  void track(FeatureProvider provider) {
+    _recordFor(provider);
+  }
 
   void bindDefault(FeatureProvider provider) {
     _recordFor(provider).defaultBinding = true;
@@ -100,7 +108,7 @@ class ProviderLifecycleManager {
   ) async {
     var errorEventEmitted = false;
     try {
-      if (provider.state == ProviderState.NOT_READY) {
+      if (_normalizeState(provider.state) == ProviderState.NOT_READY) {
         await provider.initialize();
       }
 
@@ -158,7 +166,7 @@ class ProviderLifecycleManager {
     FeatureProvider provider,
     _ProviderLifecycleRecord record,
   ) async {
-    if (provider.state != ProviderState.NOT_READY) {
+    if (_normalizeState(provider.state) != ProviderState.NOT_READY) {
       throw ProviderException(
         'Provider is not ready for initialization: ${record.status.name}',
         code: _errorCodeForState(record.status) ?? ErrorCode.PROVIDER_NOT_READY,
@@ -177,16 +185,15 @@ class ProviderLifecycleManager {
       initializationStack = stackTrace;
     }
 
-    // Provider events can use an asynchronous stream controller. Yield once so
-    // an event emitted before initialize returned can reach the SDK listener.
-    await Future<void>.delayed(Duration.zero);
-    record.initializationSignal = null;
-
-    if (!signal.isCompleted) {
+    ProviderLifecycleEvent event;
+    try {
+      event = await signal.future.timeout(_lifecycleEventTimeout);
+    } on TimeoutException {
       Error.throwWithStackTrace(
         ProviderException(
           'Provider ${provider.metadata.name} did not emit a lifecycle event '
-          'before initialization completed.',
+          'within ${_lifecycleEventTimeout.inMilliseconds}ms of '
+          'initialization.',
           code: ErrorCode.GENERAL,
           details: {
             'expected': initializationError == null
@@ -198,9 +205,11 @@ class ProviderLifecycleManager {
         ),
         initializationStack ?? StackTrace.current,
       );
+    } finally {
+      if (identical(record.initializationSignal, signal)) {
+        record.initializationSignal = null;
+      }
     }
-
-    final event = await signal.future;
     if (initializationError != null) {
       if (event.type != ProviderLifecycleEventType.PROVIDER_ERROR) {
         throw ProviderException(
@@ -273,9 +282,18 @@ class ProviderLifecycleManager {
     FeatureProvider provider,
     _ProviderLifecycleRecord record,
   ) async {
-    await provider.shutdown();
-    // Shutdown is the one lifecycle transition inferred by the SDK in v0.9.
-    record.status = ProviderState.NOT_READY;
+    try {
+      await provider.shutdown();
+      // Shutdown is the one lifecycle transition inferred by the SDK in v0.9.
+      record.status = ProviderState.NOT_READY;
+    } finally {
+      await record.eventSubscription?.cancel();
+      record.eventSubscription = null;
+      record.lifecycleObserved = false;
+      if (identical(_records[provider], record)) {
+        _records.remove(provider);
+      }
+    }
   }
 
   Future<void> dispose() async {

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -202,6 +202,18 @@ class StateProvider extends MockProvider {
   ProviderState get state => providerState;
 }
 
+class FailingInitializationProvider extends MockProvider {
+  FailingInitializationProvider(super.flags);
+
+  @override
+  ProviderState get state => ProviderState.NOT_READY;
+
+  @override
+  Future<void> initialize([Map<String, dynamic>? config]) async {
+    throw StateError('initialization failed');
+  }
+}
+
 enum ThrowingHookStage { before, after }
 
 class ThrowingHook extends BaseHook {
@@ -396,9 +408,11 @@ void main() {
         client = FeatureClient(
           metadata: ClientMetadata(name: 'test-client'),
           hookManager: hookManager,
-          apiContext: const EvaluationContext(attributes: {'global': 'value'}),
+          apiContext: const EvaluationContext(
+            attributes: {'global': 'value', 'layer': 'api'},
+          ),
           defaultContext: const EvaluationContext(
-            attributes: {'client': 'value'},
+            attributes: {'client': 'value', 'layer': 'client'},
           ),
           provider: trackingProvider,
           transactionManager: transactionManager,
@@ -406,11 +420,13 @@ void main() {
 
         await transactionManager.withContext(
           'tx',
-          {'requestId': '123'},
+          {'requestId': '123', 'layer': 'transaction'},
           () async {
             await client.track(
               'checkout',
-              context: const EvaluationContext(attributes: {'userId': 'u-1'}),
+              context: const EvaluationContext(
+                attributes: {'userId': 'u-1', 'layer': 'invocation'},
+              ),
             );
           },
         );
@@ -428,8 +444,38 @@ void main() {
           equals('value'),
         );
         expect(trackingProvider.lastTrackingContext?['userId'], equals('u-1'));
+        expect(
+          trackingProvider.lastTrackingContext?['layer'],
+          equals('invocation'),
+        );
       },
     );
+
+    test('tracking contains resolver failures', () async {
+      client = FeatureClient(
+        metadata: ClientMetadata(name: 'test-client'),
+        hookManager: hookManager,
+        defaultContext: context,
+        provider: provider,
+        providerResolver: () => throw StateError('provider lookup failed'),
+      );
+
+      await expectLater(client.track('checkout'), completes);
+      expect(client.getMetrics().trackingEvents, equals(1));
+    });
+
+    test('tracking contains context resolver failures', () async {
+      client = FeatureClient(
+        metadata: ClientMetadata(name: 'test-client'),
+        hookManager: hookManager,
+        defaultContext: context,
+        apiContextResolver: () => throw StateError('context lookup failed'),
+        provider: provider,
+      );
+
+      await expectLater(client.track('checkout'), completes);
+      expect(client.getMetrics().trackingEvents, equals(1));
+    });
 
     test('client handlers receive forwarded events', () async {
       final controller = StreamController<OpenFeatureEvent>.broadcast();
@@ -513,6 +559,7 @@ void main() {
 
     for (final testCase in <(ProviderState, ErrorCode)>[
       (ProviderState.NOT_READY, ErrorCode.PROVIDER_NOT_READY),
+      (ProviderState.SHUTDOWN, ErrorCode.PROVIDER_NOT_READY),
       (ProviderState.FATAL, ErrorCode.PROVIDER_FATAL),
     ]) {
       test(
@@ -585,6 +632,38 @@ void main() {
         () => details.flagMetadata['new'] = 'value',
         throwsUnsupportedError,
       );
+    });
+
+    test('directly constructed details copy immutable flag metadata', () {
+      final metadata = <String, dynamic>{'source': 'provider'};
+      final details = FlagEvaluationDetails<bool>(
+        flagKey: 'test-flag',
+        value: true,
+        flagMetadata: metadata,
+      );
+
+      metadata['source'] = 'caller';
+      expect(details.flagMetadata['source'], equals('provider'));
+      expect(
+        () => details.flagMetadata['new'] = 'value',
+        throwsUnsupportedError,
+      );
+    });
+
+    test('direct initialization failures do not escape the zone', () async {
+      final uncaughtErrors = <Object>[];
+
+      await runZonedGuarded(() async {
+        client = FeatureClient(
+          metadata: ClientMetadata(name: 'test-client'),
+          hookManager: hookManager,
+          defaultContext: context,
+          provider: FailingInitializationProvider({'test-flag': true}),
+        );
+        await Future<void>.delayed(Duration.zero);
+      }, (error, stack) => uncaughtErrors.add(error));
+
+      expect(uncaughtErrors, isEmpty);
     });
 
     test(

--- a/test/open_feature_api_test.dart
+++ b/test/open_feature_api_test.dart
@@ -159,19 +159,28 @@ class TestHook extends OpenFeatureHook {
 void main() {
   group('OpenFeatureAPI', () {
     setUp(() async {
-      OpenFeatureAPI.resetInstance();
-      await Future.delayed(Duration(milliseconds: 1));
+      await OpenFeatureAPI.resetInstance();
     });
 
     tearDown(() async {
-      OpenFeatureAPI.resetInstance();
-      await Future.delayed(Duration(milliseconds: 1));
+      await OpenFeatureAPI.resetInstance();
     });
 
     test('singleton instance', () {
       final api1 = OpenFeatureAPI();
       final api2 = OpenFeatureAPI();
       expect(identical(api1, api2), isTrue);
+    });
+
+    test('reset awaits disposal before creating a replacement', () async {
+      final original = OpenFeatureAPI();
+      final eventsDone = original.events.drain<void>();
+
+      await OpenFeatureAPI.resetInstance();
+      await eventsDone;
+      final replacement = OpenFeatureAPI();
+
+      expect(identical(original, replacement), isFalse);
     });
 
     test('sets and gets provider', () async {
@@ -285,7 +294,13 @@ void main() {
 
       await api.setProvider(defaultProvider);
       api.registerProvider(secondaryProvider);
+      final configured = api.events.firstWhere(
+        (event) =>
+            event.type == OpenFeatureEventType.PROVIDER_CONFIGURATION_CHANGED &&
+            event.domain == 'checkout',
+      );
       api.bindClientToProvider('checkout', secondaryProvider.metadata.name);
+      await configured;
 
       final client = api.getClient('checkout', domain: 'checkout');
       expect(

--- a/test/provider_lifecycle_test.dart
+++ b/test/provider_lifecycle_test.dart
@@ -163,12 +163,14 @@ class _EventProvider extends _LegacyProvider implements ProviderEventSource {
       StreamController<ProviderLifecycleEvent>.broadcast();
   final bool emitReady;
   final bool failInitialization;
+  final Duration readyEventDelay;
 
   _EventProvider(
     super.flags, {
     super.providerName,
     this.emitReady = true,
     this.failInitialization = false,
+    this.readyEventDelay = Duration.zero,
   });
 
   @override
@@ -194,12 +196,17 @@ class _EventProvider extends _LegacyProvider implements ProviderEventSource {
 
     _state = ProviderState.READY;
     if (emitReady) {
-      _events.add(
+      void emitReadyEvent() => _events.add(
         ProviderLifecycleEvent(
           ProviderLifecycleEventType.PROVIDER_READY,
           'Provider is ready.',
         ),
       );
+      if (readyEventDelay == Duration.zero) {
+        emitReadyEvent();
+      } else {
+        unawaited(Future<void>.delayed(readyEventDelay, emitReadyEvent));
+      }
     }
   }
 
@@ -214,13 +221,11 @@ class _DomainScopedProvider extends _EventProvider
 void main() {
   group('OpenFeature v0.9 provider lifecycle', () {
     setUp(() async {
-      OpenFeatureAPI.resetInstance();
-      await Future<void>.delayed(Duration.zero);
+      await OpenFeatureAPI.resetInstance();
     });
 
     tearDown(() async {
-      OpenFeatureAPI.resetInstance();
-      await Future<void>.delayed(Duration.zero);
+      await OpenFeatureAPI.resetInstance();
     });
 
     test('provider event updates status before API handlers run', () async {
@@ -246,7 +251,7 @@ void main() {
     });
 
     test(
-      'event-capable provider must emit before initialize returns',
+      'event-capable provider must emit within the lifecycle timeout',
       () async {
         final api = OpenFeatureAPI();
         final provider = _EventProvider({'flag': true}, emitReady: false);
@@ -263,7 +268,7 @@ void main() {
             isA<ProviderException>().having(
               (error) => error.message,
               'message',
-              contains('did not emit a lifecycle event'),
+              contains('did not emit a lifecycle event within'),
             ),
           ),
         );
@@ -298,6 +303,21 @@ void main() {
       expect(events.single.errorCode, ErrorCode.PROVIDER_FATAL);
       await subscription.cancel();
     });
+
+    test(
+      'accepts a lifecycle event emitted shortly after initialize',
+      () async {
+        final api = OpenFeatureAPI();
+        final provider = _EventProvider({
+          'flag': true,
+        }, readyEventDelay: const Duration(milliseconds: 20));
+
+        await api.setProviderAndWait(provider);
+
+        expect(api.providerStatus, ProviderState.READY);
+        expect(provider.initializeCount, 1);
+      },
+    );
 
     test(
       'legacy providers retain synthesized lifecycle compatibility',
@@ -432,6 +452,90 @@ void main() {
         expect(replacement.shutdownCount, 0);
       },
     );
+
+    test('event provider can be rebound after final shutdown', () async {
+      final api = OpenFeatureAPI();
+      final provider = _EventProvider({'flag': true}, providerName: 'first');
+      final replacement = _EventProvider({
+        'flag': false,
+      }, providerName: 'replacement');
+
+      await api.setProviderAndWait(provider);
+      await api.setProviderAndWait(replacement);
+      await api.setProviderAndWait(provider);
+
+      expect(provider.initializeCount, 2);
+      expect(provider.shutdownCount, 1);
+      expect(api.providerStatus, ProviderState.READY);
+    });
+
+    test('legacy provider can be rebound after final shutdown', () async {
+      final api = OpenFeatureAPI();
+      final provider = _LegacyProvider({'flag': true}, providerName: 'first');
+      final replacement = _LegacyProvider({
+        'flag': false,
+      }, providerName: 'replacement');
+
+      await api.setProviderAndWait(provider);
+      await api.setProviderAndWait(replacement);
+      await api.setProviderAndWait(provider);
+
+      expect(provider.initializeCount, 2);
+      expect(provider.shutdownCount, 1);
+      expect(api.providerStatus, ProviderState.READY);
+    });
+
+    test('shut-down providers stop forwarding lifecycle events', () async {
+      final api = OpenFeatureAPI();
+      final provider = _EventProvider({'flag': true}, providerName: 'first');
+      final replacement = _EventProvider({
+        'flag': false,
+      }, providerName: 'replacement');
+      final forwarded = <OpenFeatureEvent>[];
+      final subscription = api.events.listen((event) {
+        if (identical(event.provider, provider)) {
+          forwarded.add(event);
+        }
+      });
+
+      await api.setProviderAndWait(provider);
+      await api.setProviderAndWait(replacement);
+      forwarded.clear();
+      provider.emit(
+        ProviderLifecycleEvent(
+          ProviderLifecycleEventType.PROVIDER_STALE,
+          'Stale after shutdown.',
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(forwarded, isEmpty);
+      await subscription.cancel();
+    });
+
+    test('non-wait binding activates only after provider readiness', () async {
+      final api = OpenFeatureAPI();
+      final provider = _EventProvider(
+        {'flag': true},
+        providerName: 'delayed',
+        readyEventDelay: const Duration(milliseconds: 20),
+      );
+      api.registerProvider(provider, providerId: 'delayed');
+      final client = api.getClient('checkout', domain: 'checkout');
+      final configured = api.events.firstWhere(
+        (event) =>
+            event.type == OpenFeatureEventType.PROVIDER_CONFIGURATION_CHANGED &&
+            event.domain == 'checkout',
+      );
+
+      api.bindClientToProvider('checkout', 'delayed');
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      expect(identical(client.provider, provider), isFalse);
+      await configured;
+      expect(identical(client.provider, provider), isTrue);
+      expect(client.providerStatus, ProviderState.READY);
+    });
 
     test('domain-scoped provider rejects a second domain', () async {
       final api = OpenFeatureAPI();


### PR DESCRIPTION
## Summary

- make non-wait domain bindings initialize providers before activation
- release lifecycle records and event subscriptions after final shutdown
- allow legacy and event providers to reinitialize after `SHUTDOWN`
- contain direct-client initialization and tracking resolver errors
- await singleton teardown, cancel the root logger subscription, and make dispose idempotent
- make directly constructed flag metadata immutable
- add regression coverage for delayed lifecycle events, rebinding, stale events, async binding, teardown, merge precedence, and shutdown evaluation
- fix the Markdown fence reported by CodeRabbit

Addresses the actionable findings from the cumulative review on #131.

## QA

- `dart format --output=none --set-exit-if-changed .` (34 files, unchanged)
- `dart analyze` (no issues)
- `dart test` (162 passed, latest dependencies)
- `dart test --coverage=coverage` (162 passed; 76.68% line coverage)
- `dart doc` (0 warnings, 0 errors)
- `dart pub publish --dry-run` (0 warnings)
- Dart 3.12.2 minimum dependencies: `dart pub downgrade`, `dart analyze`, `dart test` (162 passed)

## Release note

Release Please should document in the generated v0.0.23 changelog that `FlagEvaluationDetails.flagMetadata` is non-nullable and immutable; mutation attempts throw `UnsupportedError`. The generated changelog is intentionally not pre-created on `development`.

## Review

This PR targets `development`, which is the repository's current QA branch. A separate approval is still required before merging and before #131 can be promoted to `main`.